### PR TITLE
Add Flow Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,38 @@ The Knowledge Base feature allows you to:
 - Quickly load and review past reports
 - Build a personal research library over time
 
+### Flow: Deep Research & Report Consolidation
+
+The Flow feature enables deep, recursive research by allowing you to:
+
+- Create visual research flows with interconnected reports
+- Generate follow-up queries based on initial research findings
+- Dive deeper into specific topics through recursive exploration
+- Consolidate multiple related reports into comprehensive final reports
+
+Key capabilities:
+
+- 🌳 **Deep Research Trees**: Start with a topic and automatically generate relevant follow-up questions to explore deeper aspects
+- 🔄 **Recursive Exploration**: Follow research paths down various "rabbit holes" by generating new queries from report insights
+- 🔍 **Visual Research Mapping**: See your entire research journey mapped out visually, showing connections between different research paths
+- 🎯 **Smart Query Generation**: AI-powered generation of follow-up research questions based on report content
+- 🔗 **Report Consolidation**: Select multiple related reports and combine them into a single, comprehensive final report
+- 📊 **Interactive Interface**: Drag, arrange, and organize your research flows visually
+
+The Flow interface makes it easy to:
+1. Start with an initial research query
+2. Review and select relevant search results
+3. Generate detailed reports from selected sources
+4. Get AI-suggested follow-up questions for deeper exploration
+5. Create new research branches from those questions
+6. Finally, consolidate related reports into comprehensive summaries
+
+This feature is perfect for:
+- Academic research requiring deep exploration of interconnected topics
+- Market research needing multiple angles of investigation
+- Complex topic analysis requiring recursive deep dives
+- Any research task where you need to "follow the thread" of information
+
 ## Configuration
 
 The app's settings can be customized through the configuration file at `lib/config.ts`. Here are the key parameters you can adjust:

--- a/README.md
+++ b/README.md
@@ -436,9 +436,9 @@ You'll need two components to use Google Custom Search:
 - [TypeScript](https://www.typescriptlang.org/) - Type safety
 - [Tailwind CSS](https://tailwindcss.com/) - Styling
 - [shadcn/ui](https://ui.shadcn.com/) - UI components
-- [Google Gemini](https://deepmind.google/technologies/gemini/) - AI model
 - [JinaAI](https://jina.ai/) - Content extraction
 - [Azure Bing Search](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api) - Web search
+- [Google Custom Search](https://developers.google.com/custom-search/v1/overview) - Web search
 - [Upstash Redis](https://upstash.com/) - Rate limiting
 - [jsPDF](https://github.com/parallax/jsPDF) & [docx](https://github.com/dolanmiu/docx) - Document generation
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <div align="center">
   <img src="demo.gif" alt="Open Deep Research Demo" width="800"/>
   <p><em>Note: Demo is sped up for brevity</em></p>
+  
+  <p><a href="https://www.loom.com/share/3c4d9811ac1d47eeaa7a0907c43aef7f">🎥 Watch the full demo video on Loom</a></p>
 </div>
 
 A powerful open-source research assistant that generates comprehensive AI-powered reports from web search results. Unlike other Deep Research solutions, it provides seamless integration with multiple AI platforms including Google, OpenAI, Anthropic, DeepSeek, and even local models - giving you the freedom to choose the perfect AI model for your specific research requirements.
@@ -60,6 +62,7 @@ Key capabilities:
 - 📊 **Interactive Interface**: Drag, arrange, and organize your research flows visually
 
 The Flow interface makes it easy to:
+
 1. Start with an initial research query
 2. Review and select relevant search results
 3. Generate detailed reports from selected sources
@@ -68,6 +71,7 @@ The Flow interface makes it easy to:
 6. Finally, consolidate related reports into comprehensive summaries
 
 This feature is perfect for:
+
 - Academic research requiring deep exploration of interconnected topics
 - Market research needing multiple angles of investigation
 - Complex topic analysis requiring recursive deep dives
@@ -340,6 +344,7 @@ You can run the application either directly on your machine or using Docker.
 #### Option 1: Traditional Setup
 
 1. Start the development server:
+
 ```bash
 npm run dev
 # or
@@ -357,11 +362,13 @@ bun dev
 If you prefer using Docker, you can build and run the application in a container after setting up your environment variables:
 
 1. Build the Docker image:
+
 ```bash
 docker build -t open-deep-research:v1 .
 ```
 
 2. Run the container:
+
 ```bash
 docker run -p 3000:3000 open-deep-research
 ```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Open Deep Research combines powerful tools to streamline research and report cre
 - ⚡ Rate limiting for stability
 - 📱 Responsive design
 
-## Demo
-
-Try it out at: [Open Deep Research](https://opendeepresearch.vercel.app/)
-
 ### Knowledge Base
 
 The Knowledge Base feature allows you to:
@@ -447,6 +443,10 @@ You'll need two components to use Google Custom Search:
 - [jsPDF](https://github.com/parallax/jsPDF) & [docx](https://github.com/dolanmiu/docx) - Document generation
 
 The app will use the configured provider (default: Google) for all searches. You can switch providers by updating the `provider` value in the config file.
+
+## Demo
+
+Try it out at: [Open Deep Research](https://opendeepresearch.vercel.app/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 <div align="center">
   <img src="demo.gif" alt="Open Deep Research Demo" width="800"/>
   <p><em>Note: Demo is sped up for brevity</em></p>
-  
-  <p><a href="https://www.loom.com/share/3c4d9811ac1d47eeaa7a0907c43aef7f">🎥 Watch the full demo video on Loom</a></p>
 </div>
 
 A powerful open-source research assistant that generates comprehensive AI-powered reports from web search results. Unlike other Deep Research solutions, it provides seamless integration with multiple AI platforms including Google, OpenAI, Anthropic, DeepSeek, and even local models - giving you the freedom to choose the perfect AI model for your specific research requirements.
@@ -44,6 +42,10 @@ The Knowledge Base feature allows you to:
 - Build a personal research library over time
 
 ### Flow: Deep Research & Report Consolidation
+
+<div align="center">
+  <p><a href="https://www.loom.com/share/3c4d9811ac1d47eeaa7a0907c43aef7f">🎥 Watch the full demo video on Loom</a></p>
+</div>
 
 The Flow feature enables deep, recursive research by allowing you to:
 

--- a/app/api/consolidate-report/route.ts
+++ b/app/api/consolidate-report/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server'
+import { CONFIG } from '@/lib/config'
+import {
+  generateWithGemini,
+  generateWithOpenAI,
+  generateWithDeepSeek,
+  generateWithAnthropic,
+  generateWithOllama,
+} from '@/lib/models'
+import type { Report } from '@/types'
+
+export async function POST(request: Request) {
+  try {
+    const { reports, platformModel } = await request.json()
+    const [platform, model] = platformModel.split('__')
+
+    console.log('Consolidating reports:', {
+      numReports: reports.length,
+      reportTitles: reports.map((r: Report) => r.title),
+      platform,
+      model
+    })
+
+    if (!reports?.length) {
+      return NextResponse.json({ error: 'Reports are required' }, { status: 400 })
+    }
+
+    const prompt = `Create a comprehensive consolidated report that synthesizes the following research reports:
+
+${reports.map((report: Report, index: number) => `
+Report ${index + 1} Title: ${report.title}
+Report ${index + 1} Summary: ${report.summary}
+Key Findings:
+${report.sections?.map(section => `- ${section.title}: ${section.content}`).join('\n')}
+`).join('\n\n')}
+
+Analyze and synthesize these reports to create a comprehensive consolidated report that:
+1. Identifies common themes and patterns across the reports
+2. Highlights key insights and findings
+3. Shows how different reports complement or contrast each other
+4. Draws overarching conclusions
+5. Suggests potential areas for further research
+
+Format the response as a structured report with:
+- A clear title that encompasses the overall research topic
+- An executive summary of the consolidated findings
+- Detailed sections that analyze different aspects
+- A conclusion that ties everything together
+
+Return the response in the following JSON format:
+{
+  "title": "Overall Research Topic Title",
+  "summary": "Executive summary of findings",
+  "sections": [
+    {
+      "title": "Section Title",
+      "content": "Section content"
+    }
+  ]
+}`
+
+    console.log('Generated prompt:', prompt)
+
+    try {
+      let response: string | null = null
+      switch (platform) {
+        case 'google':
+          if (!CONFIG.platforms.google.enabled) break
+          response = await generateWithGemini(prompt, model)
+          break
+        case 'openai':
+          if (!CONFIG.platforms.openai.enabled) break
+          response = await generateWithOpenAI(prompt, model)
+          break
+        case 'deepseek':
+          if (!CONFIG.platforms.deepseek.enabled) break
+          response = await generateWithDeepSeek(prompt, model)
+          break
+        case 'anthropic':
+          if (!CONFIG.platforms.anthropic.enabled) break
+          response = await generateWithAnthropic(prompt, model)
+          break
+        case 'ollama':
+          if (!CONFIG.platforms.ollama.enabled) break
+          response = await generateWithOllama(prompt, model)
+          break
+        default:
+          return NextResponse.json(
+            { error: 'Platform not enabled or invalid' },
+            { status: 400 }
+          )
+      }
+
+      if (!response) {
+        throw new Error('No response from model')
+      }
+
+      console.log('Model response:', response)
+
+      // Try to parse the response as JSON, if it's not already
+      let parsedResponse;
+      try {
+        parsedResponse = typeof response === 'string' ? JSON.parse(response) : response;
+        console.log('Parsed response:', parsedResponse)
+      } catch (parseError) {
+        console.error('Failed to parse response as JSON:', parseError)
+        // If it's not JSON, create a basic report structure
+        parsedResponse = {
+          title: "Consolidated Research Report",
+          summary: response.split('\n\n')[0] || "Summary not available",
+          sections: [
+            {
+              title: "Findings",
+              content: response
+            }
+          ]
+        }
+      }
+
+      return NextResponse.json(parsedResponse)
+    } catch (error) {
+      console.error('Model generation error:', error)
+      return NextResponse.json(
+        { error: 'Failed to generate consolidated report' },
+        { status: 500 }
+      )
+    }
+  } catch (error) {
+    console.error('Consolidation error:', error)
+    return NextResponse.json(
+      { error: 'Failed to consolidate reports' },
+      { status: 500 }
+    )
+  }
+} 

--- a/app/api/generate-question/route.ts
+++ b/app/api/generate-question/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server'
+import { CONFIG } from '@/lib/config'
+import {
+  generateWithGemini,
+  generateWithOpenAI,
+  generateWithDeepSeek,
+  generateWithAnthropic,
+  generateWithOllama,
+} from '@/lib/models'
+
+export async function POST(request: Request) {
+  try {
+    const { report, platformModel } = await request.json()
+    const [platform, model] = platformModel.split('__')
+
+    if (!report) {
+      return NextResponse.json({ error: 'Report is required' }, { status: 400 })
+    }
+
+    const prompt = `Based on the following research report, generate a follow-up question that would help deepen or expand the research in a meaningful way. The question should explore an important aspect that wasn't fully covered in the current report.
+
+Report Title: ${report.title}
+Summary: ${report.summary}
+
+Key Sections:
+${report.sections
+  ?.map(
+    (section: { title: string; content: string }) =>
+      `${section.title}: ${section.content}`
+  )
+  .join('\n')}
+
+Generate a single, specific follow-up question that would yield valuable additional insights.`
+
+    try {
+      let response: string | null = null
+      switch (platform) {
+        case 'google':
+          if (!CONFIG.platforms.google.enabled) break
+          response = await generateWithGemini(prompt, model)
+          break
+        case 'openai':
+          if (!CONFIG.platforms.openai.enabled) break
+          response = await generateWithOpenAI(prompt, model)
+          break
+        case 'deepseek':
+          if (!CONFIG.platforms.deepseek.enabled) break
+          response = await generateWithDeepSeek(prompt, model)
+          break
+        case 'anthropic':
+          if (!CONFIG.platforms.anthropic.enabled) break
+          response = await generateWithAnthropic(prompt, model)
+          break
+        case 'ollama':
+          if (!CONFIG.platforms.ollama.enabled) break
+          response = await generateWithOllama(prompt, model)
+          break
+        default:
+          return NextResponse.json(
+            { error: 'Platform not enabled or invalid' },
+            { status: 400 }
+          )
+      }
+
+      if (!response) {
+        throw new Error('No response from model')
+      }
+
+      return NextResponse.json({ question: response })
+    } catch (error) {
+      console.error('Model generation error:', error)
+      return NextResponse.json(
+        { error: 'Failed to generate question' },
+        { status: 500 }
+      )
+    }
+  } catch (error) {
+    console.error('Question generation error:', error)
+    return NextResponse.json(
+      { error: 'Failed to generate question' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -17,6 +17,7 @@ import {
   addEdge,
   applyNodeChanges,
   applyEdgeChanges,
+  MiniMap
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { Button } from '@/components/ui/button'
@@ -446,18 +447,6 @@ export default function FlowPage() {
     }
   }
 
-  const getReportChain = (reportId: string): Report[] => {
-    const chain: Report[] = []
-    let currentNode = nodes.find((n) => n.id === reportId)
-
-    while (currentNode?.data.report) {
-      chain.push(currentNode.data.report)
-      currentNode = nodes.find((n) => n.id === currentNode?.data.parentId)
-    }
-
-    return chain.reverse()
-  }
-
   const handleReportSelect = (reportId: string) => {
     setSelectedReports((prev) => {
       const newSelected = prev.includes(reportId)
@@ -622,6 +611,7 @@ export default function FlowPage() {
           maxZoom={1.5}
           defaultViewport={{ x: 0, y: 0, zoom: 1 }}
         >
+          <MiniMap nodeStrokeWidth={3} />
           <Background />
           <Controls />
         </ReactFlow>

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -559,7 +559,18 @@ export default function FlowPage() {
         groupNode.id
       )
 
-      setNodes((nds) => [...nds, groupNode, consolidatedNode])
+      setNodes((nds) => {
+        const updatedNodes = nds.map((node) => {
+          if (selectedReports.includes(node.id)) {
+            return {
+              ...node,
+              data: { ...node.data, isSelected: false },
+            }
+          }
+          return node
+        })
+        return [...updatedNodes, groupNode, consolidatedNode]
+      })
 
       setEdges((eds) => [
         ...eds,

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -1,16 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import type {
-  Node,
-  Edge,
-  Connection,
-  NodeTypes,
-  EdgeTypes,
-  NodeChange,
-  EdgeChange,
-  XYPosition,
-} from '@xyflow/react'
+import type { Node, Edge, Connection, NodeTypes, NodeChange, EdgeChange, XYPosition } from '@xyflow/react'
 import { ReactFlow, Controls, Background, addEdge } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { Button } from '@/components/ui/button'
@@ -22,7 +13,6 @@ import { SelectionNode } from '@/components/flow/selection-node'
 import { QuestionNode } from '@/components/flow/question-node'
 import type { SearchResult, Report } from '@/types'
 
-// Define custom node types
 const nodeTypes: NodeTypes = {
   searchNode: SearchNode,
   reportNode: ReportNode,
@@ -32,42 +22,39 @@ const nodeTypes: NodeTypes = {
 
 const DEFAULT_MODEL = 'google__gemini-flash'
 
-interface FlowNode extends Node {
-  id: string
-  type: string
-  position: XYPosition
+interface ResearchNode extends Node {
   data: {
     query?: string
     loading?: boolean
     results?: SearchResult[]
     report?: Report
     question?: string
+    parentId?: string
+    childIds?: string[]
     onGenerateReport?: (selectedResults: SearchResult[]) => void
     onApprove?: () => void
-    hasChildren?: boolean
     onConsolidate?: () => void
+    hasChildren?: boolean
+    error?: string
   }
 }
 
 export default function FlowPage() {
-  const [nodes, setNodes] = useState<FlowNode[]>([])
+  const [nodes, setNodes] = useState<ResearchNode[]>([])
   const [edges, setEdges] = useState<Edge[]>([])
   const [query, setQuery] = useState('')
   const [loading, setLoading] = useState(false)
-  const [reports, setReports] = useState<Record<string, Report>>({})
-  const [reportChains, setReportChains] = useState<Record<string, {
-    parentId: string | null;
-    childIds: string[];
-    report: Report;
-  }>>({})
 
   const onNodesChange = useCallback((changes: NodeChange[]) => {
     setNodes((nds) => {
-      return changes.reduce((acc, change) => {
+      return changes.reduce((acc: ResearchNode[], change) => {
         if (change.type === 'position' && change.position) {
+          const pos = change.position as XYPosition
+          // Ensure position values are valid numbers
+          if (isNaN(pos.x) || isNaN(pos.y)) return acc
           return acc.map((node) =>
             node.id === change.id
-              ? { ...node, position: change.position as XYPosition }
+              ? { ...node, position: { x: Math.max(0, pos.x), y: Math.max(0, pos.y) } }
               : node
           )
         }
@@ -87,210 +74,203 @@ export default function FlowPage() {
     })
   }, [])
 
-  const onConnect = useCallback(
-    (params: Connection) => {
-      setEdges((eds) => addEdge(params, eds))
-    },
-    []
-  )
+  const onConnect = useCallback((params: Connection) => {
+    setEdges((eds) => addEdge(params, eds))
+  }, [])
 
-  const createNode = (
-    type: string,
-    position: XYPosition,
-    data: FlowNode['data']
-  ): FlowNode => ({
+  const createNode = (type: string, position: XYPosition, data: ResearchNode['data']): ResearchNode => ({
     id: `${type}-${Date.now()}`,
     type,
-    position,
-    data,
+    position: {
+      x: Math.max(0, Math.round(position.x)),
+      y: Math.max(0, Math.round(position.y))
+    },
+    data: { ...data, childIds: data.childIds || [] },
   })
 
-  const handleStartResearch = async () => {
-    // Find if there's an existing search node that's loading
-    const pendingSearchNode = nodes.find(
-      node => node.type === 'searchNode' && node.data.loading
-    )
+  const calculateNewNodePosition = (parentId?: string): XYPosition => {
+    if (!parentId) {
+      // For root nodes, start at a fixed position if no nodes exist
+      if (!nodes.length) return { x: 100, y: 100 }
+      
+      // Otherwise, place below the lowest node
+      const validNodes = nodes.filter(n => 
+        !isNaN(n.position.x) && 
+        !isNaN(n.position.y) && 
+        typeof n.position.x === 'number' && 
+        typeof n.position.y === 'number'
+      )
+      
+      if (!validNodes.length) return { x: 100, y: 100 }
+      
+      const maxY = Math.max(...validNodes.map(n => n.position.y))
+      return { x: 100, y: maxY + 200 }
+    }
     
-    if (!pendingSearchNode) {
-      // This is a new search from the input field
-      if (!query.trim()) return
-      setLoading(true)
+    const parent = nodes.find(n => n.id === parentId)
+    if (!parent || isNaN(parent.position.x) || isNaN(parent.position.y)) {
+      return { x: 100, y: 100 }
+    }
 
-      try {
-        // Calculate position for new nodes based on existing nodes
-        const existingNodes = nodes.filter(node => 
-          typeof node.position.x === 'number' && 
-          typeof node.position.y === 'number' &&
-          !isNaN(node.position.x) && 
-          !isNaN(node.position.y)
-        )
-        
-        const startY = existingNodes.length > 0 
-          ? Math.max(...existingNodes.map(n => n.position.y)) + 200
-          : 50
+    const siblings = nodes.filter(n => 
+      n.data.parentId === parentId && 
+      !isNaN(n.position.x) && 
+      !isNaN(n.position.y)
+    )
 
-        // Create initial search node
-        const searchNode = createNode('searchNode', { 
-          x: 250, 
-          y: Math.max(50, startY) // Ensure minimum Y position
-        }, { 
-          query, 
-          loading: true 
-        })
-
-        // Add new node while preserving existing ones
-        setNodes((nds) => [...nds, searchNode])
-
-        await performSearch(searchNode)
-      } catch (error) {
-        console.error('Search error:', error)
-        setNodes((nds) => 
-          nds.map(node => 
-            node.type === 'searchNode' && node.data.loading
-              ? { ...node, data: { ...node.data, loading: false, error: 'Search failed' } }
-              : node
-          )
-        )
-      } finally {
-        setLoading(false)
-      }
-    } else {
-      // This is a branch search
-      try {
-        await performSearch(pendingSearchNode)
-      } catch (error) {
-        console.error('Search error:', error)
-        setNodes((nds) => 
-          nds.map(node => 
-            node.id === pendingSearchNode.id
-              ? { ...node, data: { ...node.data, loading: false, error: 'Search failed' } }
-              : node
-          )
-        )
-      }
+    return {
+      x: Math.max(0, parent.position.x + 400),
+      y: Math.max(0, parent.position.y + (siblings.length * 300))
     }
   }
 
-  const performSearch = async (searchNode: FlowNode) => {
-    if (!searchNode?.position || !searchNode.data.query) return
+  const handleStartResearch = async (parentReportId?: string) => {
+    if (!query.trim()) return
+    
+    setLoading(true)
+    try {
+      const position = calculateNewNodePosition(parentReportId)
+      const searchNode = createNode('searchNode', position, { 
+        query, 
+        loading: true, 
+        parentId: parentReportId,
+        childIds: []
+      })
+      
+      setNodes(nds => {
+        if (parentReportId) {
+          return nds.map(node => 
+            node.id === parentReportId 
+              ? { ...node, data: { ...node.data, childIds: [...(node.data.childIds || []), searchNode.id] } }
+              : node
+          ).concat(searchNode)
+        }
+        return [...nds, searchNode]
+      })
 
-    // Perform search
-    const response = await fetch('/api/search', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: searchNode.data.query,
-        timeFilter: 'all',
-        platformModel: DEFAULT_MODEL,
-      }),
-    })
-
-    if (!response.ok) throw new Error('Search failed')
-    const searchResults = await response.json()
-
-    // Create selection node with validated position
-    const selectionNode = createNode('selectionNode', 
-      { 
-        x: Math.max(0, searchNode.position.x || 250), 
-        y: Math.max(50, (searchNode.position.y || 0) + 150)
-      }, 
-      {
-        results: searchResults.webPages?.value || [],
-        onGenerateReport: handleGenerateReport,
+      if (parentReportId) {
+        setEdges(eds => [...eds, {
+          id: `edge-${parentReportId}-${searchNode.id}`,
+          source: parentReportId,
+          target: searchNode.id,
+          animated: true,
+          type: 'branch'
+        }])
       }
-    )
 
-    // Update search node and add selection node
-    setNodes((nds) => {
-      const updatedNodes = nds.map(node => 
-        node.id === searchNode.id 
-          ? { ...node, data: { ...node.data, loading: false } }
-          : node
-      )
-      return [...updatedNodes, selectionNode]
-    })
+      const response = await fetch('/api/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ 
+          query, 
+          timeFilter: 'all',
+          platformModel: DEFAULT_MODEL 
+        }),
+      })
 
-    // Add edge between search and selection
-    setEdges((eds) => [
-      ...eds,
-      {
+      if (!response.ok) throw new Error('Search failed')
+      const { webPages } = await response.json()
+
+      const selectionPosition = { 
+        x: position.x, 
+        y: position.y + 200 
+      }
+      
+      const selectionNode = createNode('selectionNode', selectionPosition, {
+        results: webPages?.value || [],
+        onGenerateReport: (selected) => handleGenerateReport(selected, searchNode.id),
+        parentId: searchNode.id,
+        childIds: []
+      })
+
+      setNodes(nds => {
+        const updatedNodes = nds.map(node => 
+          node.id === searchNode.id 
+            ? { ...node, data: { ...node.data, loading: false } }
+            : node
+        )
+        return [...updatedNodes, selectionNode]
+      })
+
+      setEdges(eds => [...eds, {
         id: `edge-${searchNode.id}-${selectionNode.id}`,
         source: searchNode.id,
         target: selectionNode.id,
-        animated: true,
-      },
-    ])
+        animated: true
+      }])
+    } catch (error) {
+      console.error('Search error:', error)
+      setNodes(nds => nds.map(node => 
+        node.data.loading ? { ...node, data: { ...node.data, loading: false, error: 'Search failed' } } : node
+      ))
+    } finally {
+      setLoading(false)
+    }
   }
 
-  const handleGenerateReport = async (selectedResults: SearchResult[]) => {
-    const reportNodeId = `report-${Date.now()}`
-    const questionNodeId = `question-${Date.now()}`
-    const selectionNode = nodes.find(node => node.type === 'selectionNode')
-    const searchNode = nodes.find(node => 
-      node.type === 'searchNode' && 
-      edges.some(edge => edge.target === selectionNode?.id && edge.source === node.id)
-    )
+  const handleGenerateReport = async (selectedResults: SearchResult[], searchNodeId: string) => {
+    const searchNode = nodes.find(n => n.id === searchNodeId)
+    if (!searchNode?.data.query || isNaN(searchNode.position.x) || isNaN(searchNode.position.y)) return
+
+    const reportPosition = calculateNewNodePosition(searchNodeId)
+    const reportNode = createNode('reportNode', reportPosition, {
+      loading: true,
+      parentId: searchNodeId,
+      childIds: [],
+      hasChildren: false
+    })
+
+    const questionPosition = { 
+      x: Math.max(0, reportPosition.x), 
+      y: Math.max(0, reportPosition.y + 200)
+    }
     
-    if (!selectionNode?.position || !searchNode?.data.query) return
+    const questionNode = createNode('questionNode', questionPosition, { 
+      loading: true,
+      parentId: reportNode.id,
+      childIds: []
+    })
+
+    setNodes(nds => [...nds, reportNode, questionNode])
+    setEdges(eds => [
+      ...eds,
+      {
+        id: `edge-${searchNodeId}-${reportNode.id}`,
+        source: searchNodeId,
+        target: reportNode.id,
+        animated: true
+      },
+      {
+        id: `edge-${reportNode.id}-${questionNode.id}`,
+        source: reportNode.id,
+        target: questionNode.id,
+        animated: true
+      }
+    ])
 
     try {
-      // Create report node with validated position
-      const reportNode = createNode('reportNode', { 
-        x: Math.max(0, selectionNode.position.x || 250), 
-        y: Math.max(50, (selectionNode.position.y || 0) + 200)
-      }, { 
-        loading: true,
-        report: undefined,
-        query: searchNode.data.query
-      })
-
-      // Create question node with validated position
-      const questionNode = createNode('questionNode', { 
-        x: Math.max(0, selectionNode.position.x || 250), 
-        y: Math.max(50, (selectionNode.position.y || 0) + 400)
-      }, { 
-        loading: true,
-        question: undefined
-      })
-
-      // Add nodes and edges
-      setNodes((nds) => [...nds, reportNode, questionNode])
-      setEdges((eds) => [
-        ...eds,
-        {
-          id: `edge-selection-${reportNodeId}`,
-          source: selectionNode.id,
-          target: reportNode.id,
-          animated: true,
-        },
-        {
-          id: `edge-${reportNodeId}-${questionNodeId}`,
-          source: reportNode.id,
-          target: questionNode.id,
-          animated: true,
-        },
-      ])
-
-      // Fetch content for each selected result
+      // Fetch content for selected results
       const contentResults = await Promise.all(
-        selectedResults.map(async (article) => {
+        selectedResults.map(async (result) => {
           try {
-            const { content } = await fetch('/api/fetch-content', {
+            const response = await fetch('/api/fetch-content', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ url: article.url }),
-            }).then(res => res.json())
-
-            if (content) {
-              return { url: article.url, title: article.name, content }
+              body: JSON.stringify({ url: result.url }),
+            })
+            const { content } = await response.json()
+            return { 
+              url: result.url, 
+              title: result.name, 
+              content: content || result.snippet 
             }
           } catch (error) {
-            console.error('Content fetch error for article:', article.url, error)
-          }
-          return {
-            url: article.url,
-            title: article.name,
-            content: article.snippet,
+            console.error('Content fetch error:', error)
+            return { 
+              url: result.url, 
+              title: result.name, 
+              content: result.snippet 
+            }
           }
         })
       )
@@ -300,7 +280,7 @@ export default function FlowPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          selectedResults: contentResults.filter((r) => r.content?.trim()),
+          selectedResults: contentResults,
           sources: selectedResults,
           prompt: `${searchNode.data.query}. Provide comprehensive analysis.`,
           platformModel: DEFAULT_MODEL,
@@ -308,29 +288,7 @@ export default function FlowPage() {
       })
 
       if (!reportResponse.ok) throw new Error('Failed to generate report')
-      const report = await reportResponse.json()
-
-      // Store report and update report chains
-      const parentReportId = nodes.find(node => 
-        node.type === 'reportNode' && 
-        edges.some(edge => edge.target === reportNode.id && edge.source === node.id)
-      )?.id
-
-      setReports((prev) => ({ ...prev, [reportNodeId]: report }))
-      setReportChains((prev) => ({
-        ...prev,
-        [reportNodeId]: {
-          parentId: parentReportId || null,
-          childIds: [],
-          report
-        },
-        ...(parentReportId ? {
-          [parentReportId]: {
-            ...prev[parentReportId],
-            childIds: [...(prev[parentReportId]?.childIds || []), reportNodeId]
-          }
-        } : {})
-      }))
+      const report: Report = await reportResponse.json()
 
       // Generate follow-up question
       const questionResponse = await fetch('/api/generate-question', {
@@ -345,154 +303,60 @@ export default function FlowPage() {
       if (!questionResponse.ok) throw new Error('Failed to generate question')
       const { question } = await questionResponse.json()
 
-      // Update nodes with data
-      setNodes((nds) =>
-        nds.map((node) => {
-          if (node.id === reportNode.id) {
-            return {
-              ...node,
-              data: {
-                ...node.data,
-                report: {
-                  title: report.title,
-                  summary: report.summary,
-                  sections: report.sections,
-                  sources: report.sources
-                },
-                loading: false,
-                hasChildren: false,
-                onConsolidate: () => consolidateReports(node.id)
-              },
+      setNodes(nds => nds.map(node => {
+        if (node.id === reportNode.id) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              report,
+              loading: false,
+              onConsolidate: () => consolidateReports(node.id)
             }
           }
-          if (node.id === questionNode.id) {
-            return {
-              ...node,
-              data: {
-                ...node.data,
-                question,
-                loading: false,
-                onApprove: () => handleStartNewBranch(question, reportNode.id),
-              },
-            }
-          }
-          return node
-        })
-      )
-
-      // Update parent node if it exists to show it has children
-      if (parentReportId) {
-        setNodes((nds) =>
-          nds.map((node) => {
-            if (node.id === parentReportId) {
-              return {
-                ...node,
-                data: {
-                  ...node.data,
-                  hasChildren: true,
-                },
+        }
+        if (node.id === questionNode.id) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              question,
+              loading: false,
+              onApprove: () => {
+                setQuery(question)
+                handleStartResearch(reportNode.id)
               }
             }
-            return node
-          })
-        )
-      }
+          }
+        }
+        return node
+      }))
     } catch (error) {
       console.error('Report generation error:', error)
-      // Update nodes to show error state
-      setNodes((nds) =>
-        nds.map((node) => {
-          if (node.id === reportNodeId || node.id === questionNodeId) {
-            return {
-              ...node,
-              data: {
-                ...node.data,
-                loading: false,
-                error: 'Failed to generate report',
-              },
-            }
-          }
-          return node
-        })
-      )
+      setNodes(nds => nds.map(node => 
+        (node.id === reportNode.id || node.id === questionNode.id)
+          ? { ...node, data: { ...node.data, loading: false, error: 'Generation failed' } }
+          : node
+      ))
     }
   }
 
-  const handleStartNewBranch = (newQuery: string, parentReportId: string) => {
-    // Find the parent report node to position the new branch
-    const parentNode = nodes.find(node => node.id === parentReportId)
-    if (!parentNode?.position) return
+  const consolidateReports = async (reportId: string) => {
+    const reportChain = getReportChain(reportId)
+    if (!reportChain.length) return
 
-    // Calculate position for new branch with validated coordinates
-    const startX = Math.max(0, (parentNode.position.x || 0) + 400)
-    const startY = Math.max(50, parentNode.position.y || 0)
-
-    // Create new search node for the branch
-    const searchNode = createNode('searchNode', { x: startX, y: startY }, { 
-      query: newQuery, 
-      loading: true 
-    })
-
-    // Add new search node
-    setNodes((nds) => [...nds, searchNode])
-
-    // Add edge from parent report to new search
-    setEdges((eds) => [
-      ...eds,
-      {
-        id: `edge-${parentReportId}-${searchNode.id}`,
-        source: parentReportId,
-        target: searchNode.id,
-        animated: true,
-        type: 'branch',
-      },
-    ])
-
-    // Start the research process with the new query
-    handleStartResearch()
-  }
-
-  const consolidateReports = async (rootReportId: string) => {
-    // Get all reports in the chain
-    const reportChain = []
-    let currentId: string | null = rootReportId
-    
-    while (currentId) {
-      const chainNode: {
-        parentId: string | null;
-        childIds: string[];
-        report: Report;
-      } = reportChains[currentId]
-      if (!chainNode) break
-      
-      reportChain.push({
-        query: nodes.find(node => node.id === currentId)?.data?.query || '',
-        report: chainNode.report
-      })
-      
-      // If this node has multiple children, we'll need user input to choose which branch
-      if (chainNode.childIds.length > 1) {
-        // For now, we'll just take the first branch
-        currentId = chainNode.childIds[0] || null
-      } else {
-        currentId = chainNode.childIds[0] || null
-      }
-    }
-
-    // Generate consolidated report
     try {
       const response = await fetch('/api/report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          selectedResults: [], // No direct sources for consolidated report
-          sources: [], // No direct sources for consolidated report
+          selectedResults: [],
+          sources: [],
           prompt: `Create a comprehensive consolidated report that synthesizes the following research chain. Each report builds upon the previous findings:
 
 ${reportChain.map((item, index) => `
-Report ${index + 1} Query: ${item.query}
-Report ${index + 1} Title: ${item.report.title}
-Report ${index + 1} Summary: ${item.report.summary}
+Report ${index + 1} Title: ${item.title}
+Report ${index + 1} Summary: ${item.summary}
 `).join('\n')}
 
 Provide a cohesive analysis that shows how the research evolved and what key insights were discovered along the way.`,
@@ -501,43 +365,49 @@ Provide a cohesive analysis that shows how the research evolved and what key ins
       })
 
       if (!response.ok) throw new Error('Failed to generate consolidated report')
-      const consolidatedReport = await response.json()
+      const consolidated: Report = await response.json()
 
-      // Find the root report node
-      const rootNode = nodes.find(node => node.id === rootReportId)
-      if (!rootNode?.position) throw new Error('Root node not found')
+      const rootNode = nodes.find(n => n.id === reportId)
+      if (!rootNode || isNaN(rootNode.position.x) || isNaN(rootNode.position.y)) {
+        throw new Error('Root node not found or has invalid position')
+      }
 
-      // Create consolidated report node with validated position
-      const consolidatedNodeId = `consolidated-${Date.now()}`
-      const consolidatedNode = createNode('reportNode', 
-        { 
-          x: Math.max(0, (rootNode.position.x || 0) + 300),
-          y: Math.max(50, rootNode.position.y || 0)
-        },
-        { 
-          report: consolidatedReport,
-          loading: false,
-        }
-      )
+      const consolidatedPosition = {
+        x: Math.max(0, rootNode.position.x + 300),
+        y: Math.max(0, rootNode.position.y)
+      }
 
-      // Add consolidated node and connect it
-      setNodes((nds) => [...nds, consolidatedNode])
-      setEdges((eds) => [
-        ...eds,
-        {
-          id: `edge-${rootReportId}-${consolidatedNodeId}`,
-          source: rootReportId,
-          target: consolidatedNodeId,
-          animated: true,
-          type: 'consolidated',
-        },
-      ])
+      const consolidatedNode = createNode('reportNode', consolidatedPosition, {
+        report: consolidated,
+        loading: false,
+        parentId: reportId,
+        childIds: [],
+        hasChildren: false
+      })
 
-      // Store consolidated report
-      setReports((prev) => ({ ...prev, [consolidatedNodeId]: consolidatedReport }))
+      setNodes(nds => [...nds, consolidatedNode])
+      setEdges(eds => [...eds, {
+        id: `edge-${reportId}-${consolidatedNode.id}`,
+        source: reportId,
+        target: consolidatedNode.id,
+        animated: true,
+        type: 'consolidated'
+      }])
     } catch (error) {
-      console.error('Failed to consolidate reports:', error)
+      console.error('Consolidation error:', error)
     }
+  }
+
+  const getReportChain = (reportId: string): Report[] => {
+    const chain: Report[] = []
+    let currentNode = nodes.find(n => n.id === reportId)
+    
+    while (currentNode?.data.report) {
+      chain.push(currentNode.data.report)
+      currentNode = nodes.find(n => n.id === currentNode?.data.parentId)
+    }
+    
+    return chain.reverse()
   }
 
   return (
@@ -547,12 +417,12 @@ Provide a cohesive analysis that shows how the research evolved and what key ins
           <Input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="What would you like to research?"
+            placeholder="Enter research topic"
             className="flex-1"
           />
           <Button
-            onClick={handleStartResearch}
-            disabled={loading || !query.trim()}
+            onClick={() => handleStartResearch()}
+            disabled={loading}
             className="gap-2"
           >
             {loading ? (
@@ -578,6 +448,9 @@ Provide a cohesive analysis that shows how the research evolved and what key ins
           onConnect={onConnect}
           nodeTypes={nodeTypes}
           fitView
+          minZoom={0.1}
+          maxZoom={1.5}
+          defaultViewport={{ x: 0, y: 0, zoom: 1 }}
         >
           <Background />
           <Controls />
@@ -585,4 +458,4 @@ Provide a cohesive analysis that shows how the research evolved and what key ins
       </div>
     </div>
   )
-} 
+}

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -73,7 +73,7 @@ interface ResearchNode extends Node {
     question?: string
     parentId?: string
     childIds?: string[]
-    onGenerateReport?: (selectedResults: SearchResult[]) => void
+    onGenerateReport?: (selectedResults: SearchResult[], prompt: string) => void
     onApprove?: (term?: string) => void
     onConsolidate?: () => void
     hasChildren?: boolean
@@ -256,9 +256,9 @@ export default function FlowPage() {
         { x: 100, y: 200 },
         {
           results: searchResults,
-          onGenerateReport: (selected) => {
-            console.log('Generate report clicked with:', selected)
-            handleGenerateReport(selected, searchNode.id, groupNode.id)
+          onGenerateReport: (selected, prompt) => {
+            console.log('Generate report clicked with:', selected, prompt)
+            handleGenerateReport(selected, searchNode.id, groupNode.id, prompt)
           },
           childIds: [],
         },
@@ -308,12 +308,14 @@ export default function FlowPage() {
   const handleGenerateReport = async (
     selectedResults: SearchResult[],
     searchNodeId: string,
-    groupId: string
+    groupId: string,
+    prompt: string
   ) => {
     console.log('handleGenerateReport called with:', {
       selectedResults,
       searchNodeId,
       groupId,
+      prompt,
     })
 
     if (selectedResults.length === 0) {
@@ -396,7 +398,8 @@ export default function FlowPage() {
         body: JSON.stringify({
           selectedResults: validResults,
           sources: selectedResults,
-          prompt: 'Provide comprehensive analysis of the selected sources.',
+          prompt:
+            prompt || 'Provide comprehensive analysis of the selected sources.',
           platformModel: selectedModel,
         }),
       })

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -145,7 +145,7 @@ export default function FlowPage() {
     position,
     style: {
       width: 800,
-      height: 1200,
+      height: 2000,
       padding: 60,
       backgroundColor: 'rgba(240, 240, 240, 0.5)',
       borderRadius: 8,

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -1,0 +1,588 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import type {
+  Node,
+  Edge,
+  Connection,
+  NodeTypes,
+  EdgeTypes,
+  NodeChange,
+  EdgeChange,
+  XYPosition,
+} from '@xyflow/react'
+import { ReactFlow, Controls, Background, addEdge } from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Brain, Search } from 'lucide-react'
+import { SearchNode } from '@/components/flow/search-node'
+import { ReportNode } from '@/components/flow/report-node'
+import { SelectionNode } from '@/components/flow/selection-node'
+import { QuestionNode } from '@/components/flow/question-node'
+import type { SearchResult, Report } from '@/types'
+
+// Define custom node types
+const nodeTypes: NodeTypes = {
+  searchNode: SearchNode,
+  reportNode: ReportNode,
+  selectionNode: SelectionNode,
+  questionNode: QuestionNode,
+}
+
+const DEFAULT_MODEL = 'google__gemini-flash'
+
+interface FlowNode extends Node {
+  id: string
+  type: string
+  position: XYPosition
+  data: {
+    query?: string
+    loading?: boolean
+    results?: SearchResult[]
+    report?: Report
+    question?: string
+    onGenerateReport?: (selectedResults: SearchResult[]) => void
+    onApprove?: () => void
+    hasChildren?: boolean
+    onConsolidate?: () => void
+  }
+}
+
+export default function FlowPage() {
+  const [nodes, setNodes] = useState<FlowNode[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [query, setQuery] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [reports, setReports] = useState<Record<string, Report>>({})
+  const [reportChains, setReportChains] = useState<Record<string, {
+    parentId: string | null;
+    childIds: string[];
+    report: Report;
+  }>>({})
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes((nds) => {
+      return changes.reduce((acc, change) => {
+        if (change.type === 'position' && change.position) {
+          return acc.map((node) =>
+            node.id === change.id
+              ? { ...node, position: change.position as XYPosition }
+              : node
+          )
+        }
+        return acc
+      }, nds)
+    })
+  }, [])
+
+  const onEdgesChange = useCallback((changes: EdgeChange[]) => {
+    setEdges((eds) => {
+      return changes.reduce((acc, change) => {
+        if (change.type === 'remove') {
+          return acc.filter((edge) => edge.id !== change.id)
+        }
+        return acc
+      }, eds)
+    })
+  }, [])
+
+  const onConnect = useCallback(
+    (params: Connection) => {
+      setEdges((eds) => addEdge(params, eds))
+    },
+    []
+  )
+
+  const createNode = (
+    type: string,
+    position: XYPosition,
+    data: FlowNode['data']
+  ): FlowNode => ({
+    id: `${type}-${Date.now()}`,
+    type,
+    position,
+    data,
+  })
+
+  const handleStartResearch = async () => {
+    // Find if there's an existing search node that's loading
+    const pendingSearchNode = nodes.find(
+      node => node.type === 'searchNode' && node.data.loading
+    )
+    
+    if (!pendingSearchNode) {
+      // This is a new search from the input field
+      if (!query.trim()) return
+      setLoading(true)
+
+      try {
+        // Calculate position for new nodes based on existing nodes
+        const existingNodes = nodes.filter(node => 
+          typeof node.position.x === 'number' && 
+          typeof node.position.y === 'number' &&
+          !isNaN(node.position.x) && 
+          !isNaN(node.position.y)
+        )
+        
+        const startY = existingNodes.length > 0 
+          ? Math.max(...existingNodes.map(n => n.position.y)) + 200
+          : 50
+
+        // Create initial search node
+        const searchNode = createNode('searchNode', { 
+          x: 250, 
+          y: Math.max(50, startY) // Ensure minimum Y position
+        }, { 
+          query, 
+          loading: true 
+        })
+
+        // Add new node while preserving existing ones
+        setNodes((nds) => [...nds, searchNode])
+
+        await performSearch(searchNode)
+      } catch (error) {
+        console.error('Search error:', error)
+        setNodes((nds) => 
+          nds.map(node => 
+            node.type === 'searchNode' && node.data.loading
+              ? { ...node, data: { ...node.data, loading: false, error: 'Search failed' } }
+              : node
+          )
+        )
+      } finally {
+        setLoading(false)
+      }
+    } else {
+      // This is a branch search
+      try {
+        await performSearch(pendingSearchNode)
+      } catch (error) {
+        console.error('Search error:', error)
+        setNodes((nds) => 
+          nds.map(node => 
+            node.id === pendingSearchNode.id
+              ? { ...node, data: { ...node.data, loading: false, error: 'Search failed' } }
+              : node
+          )
+        )
+      }
+    }
+  }
+
+  const performSearch = async (searchNode: FlowNode) => {
+    if (!searchNode?.position || !searchNode.data.query) return
+
+    // Perform search
+    const response = await fetch('/api/search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: searchNode.data.query,
+        timeFilter: 'all',
+        platformModel: DEFAULT_MODEL,
+      }),
+    })
+
+    if (!response.ok) throw new Error('Search failed')
+    const searchResults = await response.json()
+
+    // Create selection node with validated position
+    const selectionNode = createNode('selectionNode', 
+      { 
+        x: Math.max(0, searchNode.position.x || 250), 
+        y: Math.max(50, (searchNode.position.y || 0) + 150)
+      }, 
+      {
+        results: searchResults.webPages?.value || [],
+        onGenerateReport: handleGenerateReport,
+      }
+    )
+
+    // Update search node and add selection node
+    setNodes((nds) => {
+      const updatedNodes = nds.map(node => 
+        node.id === searchNode.id 
+          ? { ...node, data: { ...node.data, loading: false } }
+          : node
+      )
+      return [...updatedNodes, selectionNode]
+    })
+
+    // Add edge between search and selection
+    setEdges((eds) => [
+      ...eds,
+      {
+        id: `edge-${searchNode.id}-${selectionNode.id}`,
+        source: searchNode.id,
+        target: selectionNode.id,
+        animated: true,
+      },
+    ])
+  }
+
+  const handleGenerateReport = async (selectedResults: SearchResult[]) => {
+    const reportNodeId = `report-${Date.now()}`
+    const questionNodeId = `question-${Date.now()}`
+    const selectionNode = nodes.find(node => node.type === 'selectionNode')
+    const searchNode = nodes.find(node => 
+      node.type === 'searchNode' && 
+      edges.some(edge => edge.target === selectionNode?.id && edge.source === node.id)
+    )
+    
+    if (!selectionNode?.position || !searchNode?.data.query) return
+
+    try {
+      // Create report node with validated position
+      const reportNode = createNode('reportNode', { 
+        x: Math.max(0, selectionNode.position.x || 250), 
+        y: Math.max(50, (selectionNode.position.y || 0) + 200)
+      }, { 
+        loading: true,
+        report: undefined,
+        query: searchNode.data.query
+      })
+
+      // Create question node with validated position
+      const questionNode = createNode('questionNode', { 
+        x: Math.max(0, selectionNode.position.x || 250), 
+        y: Math.max(50, (selectionNode.position.y || 0) + 400)
+      }, { 
+        loading: true,
+        question: undefined
+      })
+
+      // Add nodes and edges
+      setNodes((nds) => [...nds, reportNode, questionNode])
+      setEdges((eds) => [
+        ...eds,
+        {
+          id: `edge-selection-${reportNodeId}`,
+          source: selectionNode.id,
+          target: reportNode.id,
+          animated: true,
+        },
+        {
+          id: `edge-${reportNodeId}-${questionNodeId}`,
+          source: reportNode.id,
+          target: questionNode.id,
+          animated: true,
+        },
+      ])
+
+      // Fetch content for each selected result
+      const contentResults = await Promise.all(
+        selectedResults.map(async (article) => {
+          try {
+            const { content } = await fetch('/api/fetch-content', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ url: article.url }),
+            }).then(res => res.json())
+
+            if (content) {
+              return { url: article.url, title: article.name, content }
+            }
+          } catch (error) {
+            console.error('Content fetch error for article:', article.url, error)
+          }
+          return {
+            url: article.url,
+            title: article.name,
+            content: article.snippet,
+          }
+        })
+      )
+
+      // Generate report
+      const reportResponse = await fetch('/api/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selectedResults: contentResults.filter((r) => r.content?.trim()),
+          sources: selectedResults,
+          prompt: `${searchNode.data.query}. Provide comprehensive analysis.`,
+          platformModel: DEFAULT_MODEL,
+        }),
+      })
+
+      if (!reportResponse.ok) throw new Error('Failed to generate report')
+      const report = await reportResponse.json()
+
+      // Store report and update report chains
+      const parentReportId = nodes.find(node => 
+        node.type === 'reportNode' && 
+        edges.some(edge => edge.target === reportNode.id && edge.source === node.id)
+      )?.id
+
+      setReports((prev) => ({ ...prev, [reportNodeId]: report }))
+      setReportChains((prev) => ({
+        ...prev,
+        [reportNodeId]: {
+          parentId: parentReportId || null,
+          childIds: [],
+          report
+        },
+        ...(parentReportId ? {
+          [parentReportId]: {
+            ...prev[parentReportId],
+            childIds: [...(prev[parentReportId]?.childIds || []), reportNodeId]
+          }
+        } : {})
+      }))
+
+      // Generate follow-up question
+      const questionResponse = await fetch('/api/generate-question', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          report,
+          platformModel: DEFAULT_MODEL,
+        }),
+      })
+
+      if (!questionResponse.ok) throw new Error('Failed to generate question')
+      const { question } = await questionResponse.json()
+
+      // Update nodes with data
+      setNodes((nds) =>
+        nds.map((node) => {
+          if (node.id === reportNode.id) {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                report: {
+                  title: report.title,
+                  summary: report.summary,
+                  sections: report.sections,
+                  sources: report.sources
+                },
+                loading: false,
+                hasChildren: false,
+                onConsolidate: () => consolidateReports(node.id)
+              },
+            }
+          }
+          if (node.id === questionNode.id) {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                question,
+                loading: false,
+                onApprove: () => handleStartNewBranch(question, reportNode.id),
+              },
+            }
+          }
+          return node
+        })
+      )
+
+      // Update parent node if it exists to show it has children
+      if (parentReportId) {
+        setNodes((nds) =>
+          nds.map((node) => {
+            if (node.id === parentReportId) {
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  hasChildren: true,
+                },
+              }
+            }
+            return node
+          })
+        )
+      }
+    } catch (error) {
+      console.error('Report generation error:', error)
+      // Update nodes to show error state
+      setNodes((nds) =>
+        nds.map((node) => {
+          if (node.id === reportNodeId || node.id === questionNodeId) {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                loading: false,
+                error: 'Failed to generate report',
+              },
+            }
+          }
+          return node
+        })
+      )
+    }
+  }
+
+  const handleStartNewBranch = (newQuery: string, parentReportId: string) => {
+    // Find the parent report node to position the new branch
+    const parentNode = nodes.find(node => node.id === parentReportId)
+    if (!parentNode?.position) return
+
+    // Calculate position for new branch with validated coordinates
+    const startX = Math.max(0, (parentNode.position.x || 0) + 400)
+    const startY = Math.max(50, parentNode.position.y || 0)
+
+    // Create new search node for the branch
+    const searchNode = createNode('searchNode', { x: startX, y: startY }, { 
+      query: newQuery, 
+      loading: true 
+    })
+
+    // Add new search node
+    setNodes((nds) => [...nds, searchNode])
+
+    // Add edge from parent report to new search
+    setEdges((eds) => [
+      ...eds,
+      {
+        id: `edge-${parentReportId}-${searchNode.id}`,
+        source: parentReportId,
+        target: searchNode.id,
+        animated: true,
+        type: 'branch',
+      },
+    ])
+
+    // Start the research process with the new query
+    handleStartResearch()
+  }
+
+  const consolidateReports = async (rootReportId: string) => {
+    // Get all reports in the chain
+    const reportChain = []
+    let currentId: string | null = rootReportId
+    
+    while (currentId) {
+      const chainNode: {
+        parentId: string | null;
+        childIds: string[];
+        report: Report;
+      } = reportChains[currentId]
+      if (!chainNode) break
+      
+      reportChain.push({
+        query: nodes.find(node => node.id === currentId)?.data?.query || '',
+        report: chainNode.report
+      })
+      
+      // If this node has multiple children, we'll need user input to choose which branch
+      if (chainNode.childIds.length > 1) {
+        // For now, we'll just take the first branch
+        currentId = chainNode.childIds[0] || null
+      } else {
+        currentId = chainNode.childIds[0] || null
+      }
+    }
+
+    // Generate consolidated report
+    try {
+      const response = await fetch('/api/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selectedResults: [], // No direct sources for consolidated report
+          sources: [], // No direct sources for consolidated report
+          prompt: `Create a comprehensive consolidated report that synthesizes the following research chain. Each report builds upon the previous findings:
+
+${reportChain.map((item, index) => `
+Report ${index + 1} Query: ${item.query}
+Report ${index + 1} Title: ${item.report.title}
+Report ${index + 1} Summary: ${item.report.summary}
+`).join('\n')}
+
+Provide a cohesive analysis that shows how the research evolved and what key insights were discovered along the way.`,
+          platformModel: DEFAULT_MODEL,
+        }),
+      })
+
+      if (!response.ok) throw new Error('Failed to generate consolidated report')
+      const consolidatedReport = await response.json()
+
+      // Find the root report node
+      const rootNode = nodes.find(node => node.id === rootReportId)
+      if (!rootNode?.position) throw new Error('Root node not found')
+
+      // Create consolidated report node with validated position
+      const consolidatedNodeId = `consolidated-${Date.now()}`
+      const consolidatedNode = createNode('reportNode', 
+        { 
+          x: Math.max(0, (rootNode.position.x || 0) + 300),
+          y: Math.max(50, rootNode.position.y || 0)
+        },
+        { 
+          report: consolidatedReport,
+          loading: false,
+        }
+      )
+
+      // Add consolidated node and connect it
+      setNodes((nds) => [...nds, consolidatedNode])
+      setEdges((eds) => [
+        ...eds,
+        {
+          id: `edge-${rootReportId}-${consolidatedNodeId}`,
+          source: rootReportId,
+          target: consolidatedNodeId,
+          animated: true,
+          type: 'consolidated',
+        },
+      ])
+
+      // Store consolidated report
+      setReports((prev) => ({ ...prev, [consolidatedNodeId]: consolidatedReport }))
+    } catch (error) {
+      console.error('Failed to consolidate reports:', error)
+    }
+  }
+
+  return (
+    <div className="h-screen flex flex-col">
+      <div className="p-4 border-b">
+        <div className="max-w-4xl mx-auto flex gap-4">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="What would you like to research?"
+            className="flex-1"
+          />
+          <Button
+            onClick={handleStartResearch}
+            disabled={loading || !query.trim()}
+            className="gap-2"
+          >
+            {loading ? (
+              <>
+                <Brain className="h-4 w-4 animate-spin" />
+                Researching...
+              </>
+            ) : (
+              <>
+                <Search className="h-4 w-4" />
+                Start Research
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+      <div className="flex-1">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          nodeTypes={nodeTypes}
+          fitView
+        >
+          <Background />
+          <Controls />
+        </ReactFlow>
+      </div>
+    </div>
+  )
+} 

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -417,7 +417,6 @@ export default function FlowPage() {
                 onApprove: (term?: string) => {
                   if (term) {
                     setQuery(term)
-                    handleStartResearch()
                   }
                 },
               },

--- a/app/flow/page.tsx
+++ b/app/flow/page.tsx
@@ -146,7 +146,7 @@ export default function FlowPage() {
     position,
     style: {
       width: 800,
-      height: 2000,
+      height: 1600,
       padding: 60,
       backgroundColor: 'rgba(240, 240, 240, 0.5)',
       borderRadius: 8,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ const zenDots = Zen_Dots({
 export const metadata: Metadata = {
   title: 'Open Deep Research',
   description:
-    'Open source alternative to Gemini Deep Research. Generate reports with AI based on search results.',
+    'Open source alternative to Deep Research. Generate reports with AI based on search results.',
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,7 +40,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
-import { useKnowledgeBase } from '@/lib/hooks/use-knowledge-base'
 import { useToast } from '@/hooks/use-toast'
 import { KnowledgeBaseSidebar } from '@/components/knowledge-base-sidebar'
 import { ReportActions } from '@/components/report-actions'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -489,7 +489,9 @@ export default function Home() {
           agentInsights: [
             ...prev.agentInsights,
             `Research strategy: ${explanation}`,
-            `Suggested structure: ${suggestedStructure.join(' → ')}`,
+            ...(Array.isArray(suggestedStructure) 
+              ? [`Suggested structure: ${suggestedStructure.join(' → ')}`]
+              : []),
           ],
         }))
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,6 @@ import { Separator } from '@/components/ui/separator'
 import {
   Search,
   FileText,
-  Download,
   Plus,
   X,
   ChevronDown,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,6 +49,7 @@ import {
 import { useKnowledgeBase } from '@/lib/hooks/use-knowledge-base'
 import { useToast } from '@/hooks/use-toast'
 import { KnowledgeBaseSidebar } from '@/components/knowledge-base-sidebar'
+import { ReportActions } from '@/components/report-actions'
 
 const timeFilters = [
   { value: 'all', label: 'Any time' },
@@ -767,47 +768,6 @@ export default function Home() {
     }))
   }, [])
 
-  const handleDownload = useCallback(
-    async (format: 'pdf' | 'docx' | 'txt') => {
-      if (!state.report) return
-
-      try {
-        const response = await fetch('/api/download', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            report: state.report,
-            format,
-          }),
-        })
-
-        const blob = await response.blob()
-        const url = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `report.${format}`
-        document.body.appendChild(a)
-        a.click()
-        window.URL.revokeObjectURL(url)
-        document.body.removeChild(a)
-      } catch (error) {
-        handleError(error, 'Download failed')
-      }
-    },
-    [state.report, handleError]
-  )
-
-  const handleSaveToKnowledgeBase = useCallback(() => {
-    if (!state.report) return
-    const success = addReport(state.report, state.reportPrompt)
-    if (success) {
-      toast({
-        title: 'Saved to Knowledge Base',
-        description: 'The report has been saved for future reference',
-      })
-    }
-  }, [state.report, state.reportPrompt, addReport, toast])
-
   return (
     <div className='min-h-screen bg-white p-4 sm:p-8'>
       <KnowledgeBaseSidebar
@@ -1334,46 +1294,10 @@ export default function Home() {
                         <h2 className='text-2xl font-bold text-gray-800 text-center sm:text-left'>
                           {state.report?.title}
                         </h2>
-                        <div className='flex w-full sm:w-auto gap-2'>
-                          <Button
-                            variant='outline'
-                            size='sm'
-                            className='gap-2'
-                            onClick={handleSaveToKnowledgeBase}
-                          >
-                            <Brain className='h-4 w-4' />
-                            Save to Knowledge Base
-                          </Button>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                variant='outline'
-                                size='sm'
-                                className='gap-2'
-                              >
-                                <Download className='h-4 w-4' />
-                                Download
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align='end'>
-                              <DropdownMenuItem
-                                onClick={() => handleDownload('pdf')}
-                              >
-                                Download as PDF
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() => handleDownload('docx')}
-                              >
-                                Download as Word
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() => handleDownload('txt')}
-                              >
-                                Download as Text
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
+                        <ReportActions 
+                          report={state.report} 
+                          prompt={state.reportPrompt}
+                        />
                       </div>
                       <p className='text-lg text-gray-700'>
                         {state.report?.summary}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,12 +25,6 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Card, CardContent } from '@/components/ui/card'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import type {
   SearchResult,
   RankingResult,
@@ -490,7 +484,7 @@ export default function Home() {
           agentInsights: [
             ...prev.agentInsights,
             `Research strategy: ${explanation}`,
-            ...(Array.isArray(suggestedStructure) 
+            ...(Array.isArray(suggestedStructure)
               ? [`Suggested structure: ${suggestedStructure.join(' → ')}`]
               : []),
           ],
@@ -1294,8 +1288,8 @@ export default function Home() {
                         <h2 className='text-2xl font-bold text-gray-800 text-center sm:text-left'>
                           {state.report?.title}
                         </h2>
-                        <ReportActions 
-                          report={state.report} 
+                        <ReportActions
+                          report={state.report}
                           prompt={state.reportPrompt}
                         />
                       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,7 +124,6 @@ export default function Home() {
     },
   })
 
-  const { addReport } = useKnowledgeBase()
   const { toast } = useToast()
 
   // Add form ref

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import {
   Brain,
   Code,
   Loader2,
+  Share,
 } from 'lucide-react'
 import {
   Select,
@@ -764,377 +765,460 @@ export default function Home() {
 
   return (
     <div className='min-h-screen bg-white p-4 sm:p-8'>
-      <KnowledgeBaseSidebar
-        open={state.sidebarOpen}
-        onOpenChange={(open) => updateState({ sidebarOpen: open })}
-      />
-      <main className='max-w-4xl mx-auto space-y-8'>
-        <div className='mb-3'>
-          <h1 className='mb-2 text-center text-gray-800 flex items-center justify-center gap-2'>
-            <img
-              src='/apple-icon.png'
-              alt='Open Deep Research'
-              className='w-6 h-6 sm:w-8 sm:h-8 rounded-full'
-            />
-            <span className='text-xl sm:text-3xl font-bold font-heading'>
-              Open Deep Research
-            </span>
-          </h1>
-          <div className='text-center space-y-3 mb-8'>
-            <p className='text-gray-600'>
-              Open source alternative to Deep Research. Generate reports with AI
-              based on search results.
-            </p>
-            <div className='flex flex-wrap justify-center items-center gap-2'>
-              <Button
-                variant='default'
-                size='sm'
-                onClick={() => updateState({ sidebarOpen: true })}
-                className='inline-flex items-center gap-1 sm:gap-2 text-xs sm:text-sm rounded-full'
-              >
-                <Brain className='h-4 w-4' />
-                View Knowledge Base
-              </Button>
-              <Button
-                asChild
-                variant='outline'
-                size='sm'
-                className='inline-flex items-center gap-1 sm:gap-2 text-xs sm:text-sm rounded-full'
-              >
-                <a
-                  href='https://github.com/btahir/open-deep-research'
-                  target='_blank'
-                  rel='noopener noreferrer'
+      <div className='fixed inset-x-0 top-0 bg-blue-50 border-b border-blue-100 p-4 flex flex-col sm:flex-row items-center justify-center gap-4 z-50'>
+        <p className='text-blue-800 text-center'>
+          <span className='font-semibold'>New:</span> Try our Visual Flow
+          feature for deep, recursive research
+        </p>
+        <Button
+          asChild
+          variant='default'
+          size='sm'
+          className='whitespace-nowrap bg-blue-600 hover:bg-blue-700'
+        >
+          <a href='/flow'>Try Flow →</a>
+        </Button>
+      </div>
+      <div className='pt-20'>
+        <KnowledgeBaseSidebar
+          open={state.sidebarOpen}
+          onOpenChange={(open) => updateState({ sidebarOpen: open })}
+        />
+        <main className='max-w-4xl mx-auto space-y-8'>
+          <div className='mb-3'>
+            <h1 className='mb-2 text-center text-gray-800 flex items-center justify-center gap-2'>
+              <img
+                src='/apple-icon.png'
+                alt='Open Deep Research'
+                className='w-6 h-6 sm:w-8 sm:h-8 rounded-full'
+              />
+              <span className='text-xl sm:text-3xl font-bold font-heading'>
+                Open Deep Research
+              </span>
+            </h1>
+            <div className='text-center space-y-3 mb-8'>
+              <p className='text-gray-600'>
+                Open source alternative to Deep Research. Generate reports with
+                AI based on search results.
+              </p>
+              <div className='flex flex-wrap justify-center items-center gap-2'>
+                <Button
+                  variant='default'
+                  size='sm'
+                  onClick={() => updateState({ sidebarOpen: true })}
+                  className='inline-flex items-center gap-1 sm:gap-2 text-xs sm:text-sm rounded-full'
                 >
-                  <Code className='h-4 w-4' />
-                  View Code
-                </a>
-              </Button>
-            </div>
-            <div className='flex justify-center items-center'>
-              <div className='flex items-center space-x-2'>
-                <Checkbox
-                  id='agent-mode'
-                  checked={state.isAgentMode}
-                  className='w-4 h-4'
-                  onCheckedChange={(checked) =>
-                    updateState({ isAgentMode: checked as boolean })
-                  }
-                />
-                <label
-                  htmlFor='agent-mode'
-                  className='text-xs sm:text-sm font-medium leading-none text-muted-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+                  <Brain className='h-4 w-4' />
+                  View Knowledge Base
+                </Button>
+                <Button
+                  asChild
+                  variant='default'
+                  size='sm'
+                  className='inline-flex items-center gap-1 sm:gap-2 text-xs sm:text-sm rounded-full'
                 >
-                  Agent Mode (Automatic search and report generation)
-                </label>
-              </div>
-            </div>
-          </div>
-          {state.status.agentStep !== 'idle' && (
-            <div className='mb-4 p-4 bg-blue-50 rounded-lg'>
-              <div className='flex items-center gap-3 mb-3'>
-                <Loader2 className='h-5 w-5 text-blue-600 animate-spin' />
-                <h3 className='font-semibold text-blue-800'>Agent Progress</h3>
-              </div>
-
-              <div className='space-y-2'>
-                <div className='flex items-center gap-2 text-sm'>
-                  <span className='font-medium'>Current Step:</span>
-                  <span className='capitalize'>{state.status.agentStep}</span>
-                </div>
-
-                {state.status.agentInsights.length > 0 && (
-                  <Collapsible>
-                    <CollapsibleTrigger className='text-sm text-blue-600 hover:underline flex items-center gap-1'>
-                      Show Research Details <ChevronDown className='h-4 w-4' />
-                    </CollapsibleTrigger>
-                    <CollapsibleContent className='mt-2 space-y-2 text-sm text-gray-600'>
-                      {state.status.agentInsights.map((insight, idx) => (
-                        <div key={idx} className='flex gap-2'>
-                          <span className='text-gray-400'>•</span>
-                          {insight}
-                        </div>
-                      ))}
-                    </CollapsibleContent>
-                  </Collapsible>
-                )}
-              </div>
-            </div>
-          )}
-          <form
-            ref={formRef}
-            onSubmit={state.isAgentMode ? handleAgentSearch : handleSearch}
-            className='space-y-4'
-          >
-            {!state.isAgentMode ? (
-              <>
-                <div className='flex flex-col sm:flex-row gap-2'>
-                  <div className='relative flex-1'>
-                    <Input
-                      type='text'
-                      value={state.query}
-                      onChange={(e) => updateState({ query: e.target.value })}
-                      placeholder='Enter your search query...'
-                      className='pr-8'
-                    />
-                    <Search className='absolute right-2 top-2 h-5 w-5 text-gray-400' />
-                  </div>
-
-                  <div className='flex flex-col sm:flex-row gap-2 sm:items-center'>
-                    <div className='flex gap-2 w-full sm:w-auto'>
-                      <Select
-                        value={state.timeFilter}
-                        onValueChange={(value) =>
-                          updateState({ timeFilter: value })
-                        }
-                      >
-                        <SelectTrigger className='flex-1 sm:flex-initial sm:w-[140px]'>
-                          <SelectValue placeholder='Select time range' />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {timeFilters.map((filter) => (
-                            <SelectItem key={filter.value} value={filter.value}>
-                              {filter.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-
-                      <Select
-                        value={state.selectedModel}
-                        onValueChange={(value) =>
-                          updateState({ selectedModel: value })
-                        }
-                        disabled={platformModels.length === 0}
-                      >
-                        <SelectTrigger className='flex-1 sm:flex-initial sm:w-[200px]'>
-                          <SelectValue
-                            placeholder={
-                              platformModels.length === 0
-                                ? 'No models available'
-                                : 'Select model'
-                            }
-                          />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {platformModels.map((model) => (
-                            <SelectItem
-                              key={model.value}
-                              value={model.value}
-                              disabled={model.disabled}
-                              className={
-                                model.disabled
-                                  ? 'text-gray-400 cursor-not-allowed'
-                                  : ''
-                              }
-                            >
-                              {model.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <Button
-                      type='submit'
-                      disabled={state.status.loading}
-                      className='w-full sm:w-auto'
-                    >
-                      {state.status.loading ? 'Searching...' : 'Search'}
-                    </Button>
-                  </div>
-                </div>
-                <div className='flex gap-2'>
-                  <Input
-                    type='url'
-                    value={state.newUrl}
-                    onChange={(e) => updateState({ newUrl: e.target.value })}
-                    placeholder='Add custom URL...'
-                    className='flex-1'
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        handleAddCustomUrl(e)
-                      }
-                    }}
-                  />
-                  <Button
-                    type='button'
-                    variant='outline'
-                    size='icon'
-                    onClick={handleAddCustomUrl}
+                  <a href='/flow'>
+                    <Share className='h-4 w-4' />
+                    Visual Flow
+                  </a>
+                </Button>
+                <Button
+                  asChild
+                  variant='outline'
+                  size='sm'
+                  className='inline-flex items-center gap-1 sm:gap-2 text-xs sm:text-sm rounded-full'
+                >
+                  <a
+                    href='https://github.com/btahir/open-deep-research'
+                    target='_blank'
+                    rel='noopener noreferrer'
                   >
-                    <Plus className='h-4 w-4' />
-                  </Button>
+                    <Code className='h-4 w-4' />
+                    View Code
+                  </a>
+                </Button>
+              </div>
+              <div className='flex justify-center items-center'>
+                <div className='flex items-center space-x-2'>
+                  <Checkbox
+                    id='agent-mode'
+                    checked={state.isAgentMode}
+                    className='w-4 h-4'
+                    onCheckedChange={(checked) =>
+                      updateState({ isAgentMode: checked as boolean })
+                    }
+                  />
+                  <label
+                    htmlFor='agent-mode'
+                    className='text-xs sm:text-sm font-medium leading-none text-muted-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+                  >
+                    Agent Mode (Automatic search and report generation)
+                  </label>
                 </div>
-              </>
-            ) : (
-              <div className='space-y-4 sm:space-y-6 lg:space-y-0'>
-                <div className='flex flex-col sm:flex-row lg:items-center gap-2'>
-                  <div className='relative flex-1'>
-                    <Input
-                      value={state.query || state.reportPrompt}
-                      onChange={(e) => {
-                        updateState({
-                          reportPrompt: e.target.value,
-                          query: '',
-                        })
-                      }}
-                      placeholder="What would you like to research? (e.g., 'Tesla Q4 2024 financial performance and market impact')"
-                      className='pr-8 text-lg'
-                    />
-                    <Brain className='absolute right-4 top-3 h-5 w-5 text-gray-400' />
+              </div>
+            </div>
+            {state.status.agentStep !== 'idle' && (
+              <div className='mb-4 p-4 bg-blue-50 rounded-lg'>
+                <div className='flex items-center gap-3 mb-3'>
+                  <Loader2 className='h-5 w-5 text-blue-600 animate-spin' />
+                  <h3 className='font-semibold text-blue-800'>
+                    Agent Progress
+                  </h3>
+                </div>
+
+                <div className='space-y-2'>
+                  <div className='flex items-center gap-2 text-sm'>
+                    <span className='font-medium'>Current Step:</span>
+                    <span className='capitalize'>{state.status.agentStep}</span>
                   </div>
-                  <div className='flex flex-col sm:flex-row lg:flex-nowrap gap-2 sm:items-center'>
-                    <div className='w-full sm:w-[200px]'>
-                      <Select
-                        value={state.selectedModel}
-                        onValueChange={(value) =>
-                          updateState({ selectedModel: value })
-                        }
-                        disabled={platformModels.length === 0}
-                      >
-                        <SelectTrigger>
-                          <SelectValue
-                            placeholder={
-                              platformModels.length === 0
-                                ? 'No models available'
-                                : 'Select model'
-                            }
-                          />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {platformModels.map((model) => (
-                            <SelectItem
-                              key={model.value}
-                              value={model.value}
-                              disabled={model.disabled}
-                              className={
-                                model.disabled
-                                  ? 'text-gray-400 cursor-not-allowed'
-                                  : ''
-                              }
-                            >
-                              {model.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <Button
-                      type='submit'
-                      disabled={state.status.agentStep !== 'idle'}
-                      className='w-full sm:w-auto lg:w-[200px] bg-blue-600 hover:bg-blue-700 text-white whitespace-nowrap'
-                    >
-                      {state.status.agentStep !== 'idle' ? (
-                        <span className='flex items-center gap-2'>
-                          <Loader2 className='h-4 w-4 animate-spin' />
-                          {
-                            {
-                              processing: 'Planning Research...',
-                              searching: 'Searching Web...',
-                              analyzing: 'Analyzing Results...',
-                              generating: 'Writing Report...',
-                            }[state.status.agentStep]
-                          }
-                        </span>
-                      ) : (
-                        'Start Deep Research'
-                      )}
-                    </Button>
-                  </div>
+
+                  {state.status.agentInsights.length > 0 && (
+                    <Collapsible>
+                      <CollapsibleTrigger className='text-sm text-blue-600 hover:underline flex items-center gap-1'>
+                        Show Research Details{' '}
+                        <ChevronDown className='h-4 w-4' />
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className='mt-2 space-y-2 text-sm text-gray-600'>
+                        {state.status.agentInsights.map((insight, idx) => (
+                          <div key={idx} className='flex gap-2'>
+                            <span className='text-gray-400'>•</span>
+                            {insight}
+                          </div>
+                        ))}
+                      </CollapsibleContent>
+                    </Collapsible>
+                  )}
                 </div>
               </div>
             )}
-          </form>
-        </div>
+            <form
+              ref={formRef}
+              onSubmit={state.isAgentMode ? handleAgentSearch : handleSearch}
+              className='space-y-4'
+            >
+              {!state.isAgentMode ? (
+                <>
+                  <div className='flex flex-col sm:flex-row gap-2'>
+                    <div className='relative flex-1'>
+                      <Input
+                        type='text'
+                        value={state.query}
+                        onChange={(e) => updateState({ query: e.target.value })}
+                        placeholder='Enter your search query...'
+                        className='pr-8'
+                      />
+                      <Search className='absolute right-2 top-2 h-5 w-5 text-gray-400' />
+                    </div>
 
-        <Separator className='my-8' />
+                    <div className='flex flex-col sm:flex-row gap-2 sm:items-center'>
+                      <div className='flex gap-2 w-full sm:w-auto'>
+                        <Select
+                          value={state.timeFilter}
+                          onValueChange={(value) =>
+                            updateState({ timeFilter: value })
+                          }
+                        >
+                          <SelectTrigger className='flex-1 sm:flex-initial sm:w-[140px]'>
+                            <SelectValue placeholder='Select time range' />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {timeFilters.map((filter) => (
+                              <SelectItem
+                                key={filter.value}
+                                value={filter.value}
+                              >
+                                {filter.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
 
-        {state.error && (
-          <div className='p-4 mb-4 bg-red-50 border border-red-200 rounded-lg'>
-            <div className='flex items-center gap-2 text-red-700'>
-              <div>
-                <h3 className='font-semibold'>Error</h3>
-                <p className='text-sm'>{state.error}</p>
-              </div>
-            </div>
-          </div>
-        )}
+                        <Select
+                          value={state.selectedModel}
+                          onValueChange={(value) =>
+                            updateState({ selectedModel: value })
+                          }
+                          disabled={platformModels.length === 0}
+                        >
+                          <SelectTrigger className='flex-1 sm:flex-initial sm:w-[200px]'>
+                            <SelectValue
+                              placeholder={
+                                platformModels.length === 0
+                                  ? 'No models available'
+                                  : 'Select model'
+                              }
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {platformModels.map((model) => (
+                              <SelectItem
+                                key={model.value}
+                                value={model.value}
+                                disabled={model.disabled}
+                                className={
+                                  model.disabled
+                                    ? 'text-gray-400 cursor-not-allowed'
+                                    : ''
+                                }
+                              >
+                                {model.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
 
-        {state.results.length > 0 && (
-          <Tabs
-            value={state.activeTab}
-            onValueChange={(value) => updateState({ activeTab: value })}
-            className='w-full'
-          >
-            <div className='mb-6 space-y-4'>
-              {state.selectedResults.length > 0 && !state.isAgentMode && (
-                <div className='flex flex-col sm:flex-row gap-2'>
-                  <div className='relative flex-1'>
-                    <Input
-                      value={state.reportPrompt}
-                      onChange={(e) =>
-                        updateState({ reportPrompt: e.target.value })
-                      }
-                      placeholder="What would you like to know about these sources? (e.g., 'Compare and analyze the key points')"
-                      className='pr-8'
-                    />
-                    <FileText className='absolute right-2 top-2.5 h-5 w-5 text-gray-400' />
+                      <Button
+                        type='submit'
+                        disabled={state.status.loading}
+                        className='w-full sm:w-auto'
+                      >
+                        {state.status.loading ? 'Searching...' : 'Search'}
+                      </Button>
+                    </div>
                   </div>
-                  <Button
-                    onClick={generateReport}
-                    disabled={
-                      !state.reportPrompt.trim() ||
-                      state.status.generatingReport ||
-                      !state.selectedModel
-                    }
-                    type='button'
-                    className='w-full sm:w-auto whitespace-nowrap bg-blue-600 hover:bg-blue-700 text-white'
-                  >
-                    {state.status.generatingReport ? (
-                      <span className='flex items-center gap-2'>
-                        <Loader2 className='h-4 w-4 animate-spin' />
-                        Generating...
-                      </span>
-                    ) : (
-                      'Generate Report'
-                    )}
-                  </Button>
+                  <div className='flex gap-2'>
+                    <Input
+                      type='url'
+                      value={state.newUrl}
+                      onChange={(e) => updateState({ newUrl: e.target.value })}
+                      placeholder='Add custom URL...'
+                      className='flex-1'
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          handleAddCustomUrl(e)
+                        }
+                      }}
+                    />
+                    <Button
+                      type='button'
+                      variant='outline'
+                      size='icon'
+                      onClick={handleAddCustomUrl}
+                    >
+                      <Plus className='h-4 w-4' />
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className='space-y-4 sm:space-y-6 lg:space-y-0'>
+                  <div className='flex flex-col sm:flex-row lg:items-center gap-2'>
+                    <div className='relative flex-1'>
+                      <Input
+                        value={state.query || state.reportPrompt}
+                        onChange={(e) => {
+                          updateState({
+                            reportPrompt: e.target.value,
+                            query: '',
+                          })
+                        }}
+                        placeholder="What would you like to research? (e.g., 'Tesla Q4 2024 financial performance and market impact')"
+                        className='pr-8 text-lg'
+                      />
+                      <Brain className='absolute right-4 top-3 h-5 w-5 text-gray-400' />
+                    </div>
+                    <div className='flex flex-col sm:flex-row lg:flex-nowrap gap-2 sm:items-center'>
+                      <div className='w-full sm:w-[200px]'>
+                        <Select
+                          value={state.selectedModel}
+                          onValueChange={(value) =>
+                            updateState({ selectedModel: value })
+                          }
+                          disabled={platformModels.length === 0}
+                        >
+                          <SelectTrigger>
+                            <SelectValue
+                              placeholder={
+                                platformModels.length === 0
+                                  ? 'No models available'
+                                  : 'Select model'
+                              }
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {platformModels.map((model) => (
+                              <SelectItem
+                                key={model.value}
+                                value={model.value}
+                                disabled={model.disabled}
+                                className={
+                                  model.disabled
+                                    ? 'text-gray-400 cursor-not-allowed'
+                                    : ''
+                                }
+                              >
+                                {model.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <Button
+                        type='submit'
+                        disabled={state.status.agentStep !== 'idle'}
+                        className='w-full sm:w-auto lg:w-[200px] bg-blue-600 hover:bg-blue-700 text-white whitespace-nowrap'
+                      >
+                        {state.status.agentStep !== 'idle' ? (
+                          <span className='flex items-center gap-2'>
+                            <Loader2 className='h-4 w-4 animate-spin' />
+                            {
+                              {
+                                processing: 'Planning Research...',
+                                searching: 'Searching Web...',
+                                analyzing: 'Analyzing Results...',
+                                generating: 'Writing Report...',
+                              }[state.status.agentStep]
+                            }
+                          </span>
+                        ) : (
+                          'Start Deep Research'
+                        )}
+                      </Button>
+                    </div>
+                  </div>
                 </div>
               )}
-              <div className='text-sm text-gray-600 text-center sm:text-left space-y-1'>
-                <p>
-                  {state.selectedResults.length === 0
-                    ? 'Select up to 3 results to generate a report'
-                    : state.selectedModel
-                    ? `${state.selectedResults.length} of ${MAX_SELECTIONS} results selected`
-                    : 'Please select a model above to generate a report'}
-                </p>
-                {state.status.generatingReport && (
-                  <p>
-                    {state.status.fetchStatus.successful} fetched,{' '}
-                    {state.status.fetchStatus.fallback} failed (of{' '}
-                    {state.status.fetchStatus.total})
-                  </p>
-                )}
-              </div>
-              <TabsList className='grid w-full grid-cols-2 mb-4'>
-                <TabsTrigger value='search'>Search Results</TabsTrigger>
-                <TabsTrigger value='report' disabled={!state.report}>
-                  Report
-                </TabsTrigger>
-              </TabsList>
+            </form>
+          </div>
 
-              <TabsContent value='search' className='space-y-4'>
-                {!state.isAgentMode &&
-                  state.results
-                    .filter((r) => r.isCustomUrl)
+          <Separator className='my-8' />
+
+          {state.error && (
+            <div className='p-4 mb-4 bg-red-50 border border-red-200 rounded-lg'>
+              <div className='flex items-center gap-2 text-red-700'>
+                <div>
+                  <h3 className='font-semibold'>Error</h3>
+                  <p className='text-sm'>{state.error}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {state.results.length > 0 && (
+            <Tabs
+              value={state.activeTab}
+              onValueChange={(value) => updateState({ activeTab: value })}
+              className='w-full'
+            >
+              <div className='mb-6 space-y-4'>
+                {state.selectedResults.length > 0 && !state.isAgentMode && (
+                  <div className='flex flex-col sm:flex-row gap-2'>
+                    <div className='relative flex-1'>
+                      <Input
+                        value={state.reportPrompt}
+                        onChange={(e) =>
+                          updateState({ reportPrompt: e.target.value })
+                        }
+                        placeholder="What would you like to know about these sources? (e.g., 'Compare and analyze the key points')"
+                        className='pr-8'
+                      />
+                      <FileText className='absolute right-2 top-2.5 h-5 w-5 text-gray-400' />
+                    </div>
+                    <Button
+                      onClick={generateReport}
+                      disabled={
+                        !state.reportPrompt.trim() ||
+                        state.status.generatingReport ||
+                        !state.selectedModel
+                      }
+                      type='button'
+                      className='w-full sm:w-auto whitespace-nowrap bg-blue-600 hover:bg-blue-700 text-white'
+                    >
+                      {state.status.generatingReport ? (
+                        <span className='flex items-center gap-2'>
+                          <Loader2 className='h-4 w-4 animate-spin' />
+                          Generating...
+                        </span>
+                      ) : (
+                        'Generate Report'
+                      )}
+                    </Button>
+                  </div>
+                )}
+                <div className='text-sm text-gray-600 text-center sm:text-left space-y-1'>
+                  <p>
+                    {state.selectedResults.length === 0
+                      ? 'Select up to 3 results to generate a report'
+                      : state.selectedModel
+                      ? `${state.selectedResults.length} of ${MAX_SELECTIONS} results selected`
+                      : 'Please select a model above to generate a report'}
+                  </p>
+                  {state.status.generatingReport && (
+                    <p>
+                      {state.status.fetchStatus.successful} fetched,{' '}
+                      {state.status.fetchStatus.fallback} failed (of{' '}
+                      {state.status.fetchStatus.total})
+                    </p>
+                  )}
+                </div>
+                <TabsList className='grid w-full grid-cols-2 mb-4'>
+                  <TabsTrigger value='search'>Search Results</TabsTrigger>
+                  <TabsTrigger value='report' disabled={!state.report}>
+                    Report
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value='search' className='space-y-4'>
+                  {!state.isAgentMode &&
+                    state.results
+                      .filter((r) => r.isCustomUrl)
+                      .map((result) => (
+                        <Card
+                          key={result.id}
+                          className='overflow-hidden border-2 border-blue-100'
+                        >
+                          <CardContent className='p-4 flex gap-4'>
+                            <div className='pt-1'>
+                              <Checkbox
+                                checked={state.selectedResults.includes(
+                                  result.id
+                                )}
+                                onCheckedChange={() =>
+                                  handleResultSelect(result.id)
+                                }
+                                disabled={
+                                  !state.selectedResults.includes(result.id) &&
+                                  state.selectedResults.length >= MAX_SELECTIONS
+                                }
+                              />
+                            </div>
+                            <div className='flex-1 min-w-0'>
+                              <div className='flex justify-between items-start'>
+                                <a
+                                  href={result.url}
+                                  target='_blank'
+                                  rel='noopener noreferrer'
+                                  className='text-blue-600 hover:underline'
+                                >
+                                  <h2 className='text-xl font-semibold truncate'>
+                                    {result.name}
+                                  </h2>
+                                </a>
+                                <Button
+                                  variant='ghost'
+                                  size='sm'
+                                  onClick={() => handleRemoveResult(result.id)}
+                                  className='ml-2'
+                                >
+                                  <X className='h-4 w-4' />
+                                </Button>
+                              </div>
+                              <p className='text-green-700 text-sm truncate'>
+                                {result.url}
+                              </p>
+                              <p className='mt-1 text-gray-600 line-clamp-2'>
+                                {result.snippet}
+                              </p>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      ))}
+
+                  {state.results
+                    .filter((r) => !r.isCustomUrl)
                     .map((result) => (
-                      <Card
-                        key={result.id}
-                        className='overflow-hidden border-2 border-blue-100'
-                      >
+                      <Card key={result.id} className='overflow-hidden'>
                         <CardContent className='p-4 flex gap-4'>
                           <div className='pt-1'>
                             <Checkbox
@@ -1151,171 +1235,131 @@ export default function Home() {
                             />
                           </div>
                           <div className='flex-1 min-w-0'>
-                            <div className='flex justify-between items-start'>
+                            <h2 className='text-xl font-semibold truncate text-blue-600 hover:underline'>
                               <a
                                 href={result.url}
                                 target='_blank'
                                 rel='noopener noreferrer'
-                                className='text-blue-600 hover:underline'
-                              >
-                                <h2 className='text-xl font-semibold truncate'>
-                                  {result.name}
-                                </h2>
-                              </a>
-                              <Button
-                                variant='ghost'
-                                size='sm'
-                                onClick={() => handleRemoveResult(result.id)}
-                                className='ml-2'
-                              >
-                                <X className='h-4 w-4' />
-                              </Button>
-                            </div>
+                                dangerouslySetInnerHTML={{
+                                  __html: result.name,
+                                }}
+                              />
+                            </h2>
                             <p className='text-green-700 text-sm truncate'>
                               {result.url}
                             </p>
-                            <p className='mt-1 text-gray-600 line-clamp-2'>
-                              {result.snippet}
-                            </p>
+                            <p
+                              className='mt-1 text-gray-600 line-clamp-2'
+                              dangerouslySetInnerHTML={{
+                                __html: result.snippet,
+                              }}
+                            />
                           </div>
                         </CardContent>
                       </Card>
                     ))}
+                </TabsContent>
 
-                {state.results
-                  .filter((r) => !r.isCustomUrl)
-                  .map((result) => (
-                    <Card key={result.id} className='overflow-hidden'>
-                      <CardContent className='p-4 flex gap-4'>
-                        <div className='pt-1'>
-                          <Checkbox
-                            checked={state.selectedResults.includes(result.id)}
-                            onCheckedChange={() =>
-                              handleResultSelect(result.id)
-                            }
-                            disabled={
-                              !state.selectedResults.includes(result.id) &&
-                              state.selectedResults.length >= MAX_SELECTIONS
-                            }
-                          />
-                        </div>
-                        <div className='flex-1 min-w-0'>
-                          <h2 className='text-xl font-semibold truncate text-blue-600 hover:underline'>
-                            <a
-                              href={result.url}
-                              target='_blank'
-                              rel='noopener noreferrer'
-                              dangerouslySetInnerHTML={{ __html: result.name }}
+                <TabsContent value='report'>
+                  {state.report && (
+                    <Card>
+                      <CardContent className='p-6 space-y-6'>
+                        <Collapsible
+                          open={state.isSourcesOpen}
+                          onOpenChange={(open) =>
+                            updateState({ isSourcesOpen: open })
+                          }
+                          className='w-full border rounded-lg p-2'
+                        >
+                          <CollapsibleTrigger className='flex items-center justify-between w-full'>
+                            <span className='text-sm font-medium'>
+                              Overview
+                            </span>
+                            <ChevronDown
+                              className={`h-4 w-4 transition-transform ${
+                                state.isSourcesOpen
+                                  ? 'transform rotate-180'
+                                  : ''
+                              }`}
                             />
-                          </h2>
-                          <p className='text-green-700 text-sm truncate'>
-                            {result.url}
-                          </p>
-                          <p
-                            className='mt-1 text-gray-600 line-clamp-2'
-                            dangerouslySetInnerHTML={{ __html: result.snippet }}
-                          />
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-              </TabsContent>
-
-              <TabsContent value='report'>
-                {state.report && (
-                  <Card>
-                    <CardContent className='p-6 space-y-6'>
-                      <Collapsible
-                        open={state.isSourcesOpen}
-                        onOpenChange={(open) =>
-                          updateState({ isSourcesOpen: open })
-                        }
-                        className='w-full border rounded-lg p-2'
-                      >
-                        <CollapsibleTrigger className='flex items-center justify-between w-full'>
-                          <span className='text-sm font-medium'>Overview</span>
-                          <ChevronDown
-                            className={`h-4 w-4 transition-transform ${
-                              state.isSourcesOpen ? 'transform rotate-180' : ''
-                            }`}
-                          />
-                        </CollapsibleTrigger>
-                        <CollapsibleContent className='space-y-4 mt-2'>
-                          <div className='text-sm text-gray-600 bg-gray-50 p-3 rounded'>
-                            <p className='font-medium text-gray-700'>
-                              {state.status.fetchStatus.successful} of{' '}
-                              {state.report?.sources?.length || 0} sources
-                              fetched successfully
-                            </p>
-                          </div>
-                          <div className='space-y-2'>
-                            {state.report?.sources?.map((source) => (
-                              <div key={source.id} className='text-gray-600'>
-                                <div className='flex items-center gap-2'>
-                                  <a
-                                    href={source.url}
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    className='text-blue-600 hover:underline'
-                                  >
-                                    {source.name}
-                                  </a>
-                                  <span
-                                    className={`text-xs px-1.5 py-0.5 rounded ${
-                                      state.status.fetchStatus.sourceStatuses[
+                          </CollapsibleTrigger>
+                          <CollapsibleContent className='space-y-4 mt-2'>
+                            <div className='text-sm text-gray-600 bg-gray-50 p-3 rounded'>
+                              <p className='font-medium text-gray-700'>
+                                {state.status.fetchStatus.successful} of{' '}
+                                {state.report?.sources?.length || 0} sources
+                                fetched successfully
+                              </p>
+                            </div>
+                            <div className='space-y-2'>
+                              {state.report?.sources?.map((source) => (
+                                <div key={source.id} className='text-gray-600'>
+                                  <div className='flex items-center gap-2'>
+                                    <a
+                                      href={source.url}
+                                      target='_blank'
+                                      rel='noopener noreferrer'
+                                      className='text-blue-600 hover:underline'
+                                    >
+                                      {source.name}
+                                    </a>
+                                    <span
+                                      className={`text-xs px-1.5 py-0.5 rounded ${
+                                        state.status.fetchStatus.sourceStatuses[
+                                          source.url
+                                        ] === 'fetched'
+                                          ? 'bg-green-100 text-green-700'
+                                          : 'bg-yellow-50 text-yellow-600'
+                                      }`}
+                                    >
+                                      {state.status.fetchStatus.sourceStatuses[
                                         source.url
                                       ] === 'fetched'
-                                        ? 'bg-green-100 text-green-700'
-                                        : 'bg-yellow-50 text-yellow-600'
-                                    }`}
-                                  >
-                                    {state.status.fetchStatus.sourceStatuses[
-                                      source.url
-                                    ] === 'fetched'
-                                      ? 'fetched'
-                                      : 'preview'}
-                                  </span>
+                                        ? 'fetched'
+                                        : 'preview'}
+                                    </span>
+                                  </div>
+                                  <p className='text-sm text-gray-500'>
+                                    {source.url}
+                                  </p>
                                 </div>
-                                <p className='text-sm text-gray-500'>
-                                  {source.url}
-                                </p>
-                              </div>
-                            ))}
-                          </div>
-                        </CollapsibleContent>
-                      </Collapsible>
-                      <div className='flex flex-col-reverse sm:flex-row sm:justify-between sm:items-start gap-4'>
-                        <h2 className='text-2xl font-bold text-gray-800 text-center sm:text-left'>
-                          {state.report?.title}
-                        </h2>
-                        <ReportActions
-                          report={state.report}
-                          prompt={state.reportPrompt}
-                        />
-                      </div>
-                      <p className='text-lg text-gray-700'>
-                        {state.report?.summary}
-                      </p>
-                      {state.report?.sections?.map((section, index) => (
-                        <div key={index} className='space-y-2 border-t pt-4'>
-                          <h3 className='text-xl font-semibold text-gray-700'>
-                            {section.title}
-                          </h3>
-                          <div className='prose max-w-none text-gray-600'>
-                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                              {section.content}
-                            </ReactMarkdown>
-                          </div>
+                              ))}
+                            </div>
+                          </CollapsibleContent>
+                        </Collapsible>
+                        <div className='flex flex-col-reverse sm:flex-row sm:justify-between sm:items-start gap-4'>
+                          <h2 className='text-2xl font-bold text-gray-800 text-center sm:text-left'>
+                            {state.report?.title}
+                          </h2>
+                          <ReportActions
+                            report={state.report}
+                            prompt={state.reportPrompt}
+                          />
                         </div>
-                      ))}
-                    </CardContent>
-                  </Card>
-                )}
-              </TabsContent>
-            </div>
-          </Tabs>
-        )}
-      </main>
+                        <p className='text-lg text-gray-700'>
+                          {state.report?.summary}
+                        </p>
+                        {state.report?.sections?.map((section, index) => (
+                          <div key={index} className='space-y-2 border-t pt-4'>
+                            <h3 className='text-xl font-semibold text-gray-700'>
+                              {section.title}
+                            </h3>
+                            <div className='prose max-w-none text-gray-600'>
+                              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                                {section.content}
+                              </ReactMarkdown>
+                            </div>
+                          </div>
+                        ))}
+                      </CardContent>
+                    </Card>
+                  )}
+                </TabsContent>
+              </div>
+            </Tabs>
+          )}
+        </main>
+      </div>
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -467,9 +467,9 @@ export default function Home() {
             const response = await fetch('/api/optimize-research', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ 
+              body: JSON.stringify({
                 prompt: state.reportPrompt,
-                platformModel: state.selectedModel 
+                platformModel: state.selectedModel,
               }),
             })
             if (!response.ok) {
@@ -559,7 +559,7 @@ export default function Home() {
                 url: r.url,
               })),
               isTestQuery: query.toLowerCase() === 'test',
-              platformModel: state.selectedModel
+              platformModel: state.selectedModel,
             }),
           })
           if (!response.ok) {
@@ -826,8 +826,8 @@ export default function Home() {
           </h1>
           <div className='text-center space-y-3 mb-8'>
             <p className='text-gray-600'>
-              Open source alternative to Gemini Deep Research. Generate reports
-              with AI based on search results.
+              Open source alternative to Deep Research. Generate reports with AI
+              based on search results.
             </p>
             <div className='flex flex-wrap justify-center items-center gap-2'>
               <Button

--- a/app/report/[id]/report-content.tsx
+++ b/app/report/[id]/report-content.tsx
@@ -11,6 +11,7 @@ import remarkGfm from 'remark-gfm'
 import { formatDistanceToNow } from 'date-fns'
 import { useKnowledgeBase } from '@/lib/hooks/use-knowledge-base'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { ReportActions } from '@/components/report-actions'
 
 export function ReportContent({ id }: any) {
   const router = useRouter()
@@ -70,15 +71,23 @@ export function ReportContent({ id }: any) {
             <ArrowLeft className='h-4 w-4' />
             Back
           </Button>
-          <Button
-            variant='destructive'
-            size='sm'
-            onClick={() => setShowDeleteConfirm(true)}
-            className='gap-2'
-          >
-            <Trash2 className='h-4 w-4' />
-            Delete Report
-          </Button>
+          <div className='flex gap-2'>
+            <ReportActions
+              report={report?.report}
+              prompt={report?.query}
+              size='sm'
+              hideKnowledgeBase={true}
+            />
+            <Button
+              variant='destructive'
+              size='sm'
+              onClick={() => setShowDeleteConfirm(true)}
+              className='gap-2'
+            >
+              <Trash2 className='h-4 w-4' />
+              Delete Report
+            </Button>
+          </div>
         </div>
 
         {showDeleteConfirm && (

--- a/components/flow/question-node.tsx
+++ b/components/flow/question-node.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react'
-import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'

--- a/components/flow/question-node.tsx
+++ b/components/flow/question-node.tsx
@@ -1,0 +1,55 @@
+import { memo } from 'react'
+import type { Node } from '@xyflow/react'
+import { Handle, Position } from '@xyflow/react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { HelpCircle, Loader2, AlertCircle } from 'lucide-react'
+
+type QuestionNodeData = {
+  question?: string
+  loading: boolean
+  error?: string
+  onApprove?: () => void
+}
+
+type QuestionNodeType = Node<QuestionNodeData>
+
+export const QuestionNode = memo(function QuestionNode({
+  data,
+}: {
+  data: QuestionNodeData
+}) {
+  return (
+    <Card className="min-w-[400px]">
+      <Handle type="target" position={Position.Top} />
+      <CardContent className="p-4">
+        {data.loading ? (
+          <div className="flex items-center gap-3">
+            <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+            <p>Generating follow-up question...</p>
+          </div>
+        ) : data.error ? (
+          <div className="flex items-center gap-3 text-red-500">
+            <AlertCircle className="h-5 w-5" />
+            <p>{data.error}</p>
+          </div>
+        ) : data.question ? (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <HelpCircle className="h-5 w-5 text-blue-500" />
+              <h3 className="font-medium">Follow-up Question</h3>
+            </div>
+            <p className="text-gray-600">{data.question}</p>
+            <Button
+              size="sm"
+              className="w-full"
+              onClick={data.onApprove}
+            >
+              Research This Question
+            </Button>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}) 

--- a/components/flow/question-node.tsx
+++ b/components/flow/question-node.tsx
@@ -3,53 +3,63 @@ import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { HelpCircle, Loader2, AlertCircle } from 'lucide-react'
+import { Search, Loader2 } from 'lucide-react'
 
-type QuestionNodeData = {
-  question?: string
+type SearchTermsNodeData = {
+  searchTerms?: string[]
   loading: boolean
   error?: string
-  onApprove?: () => void
+  onApprove?: (term: string) => void
 }
 
-type QuestionNodeType = Node<QuestionNodeData>
+type SearchTermsNodeType = Node<SearchTermsNodeData>
 
-export const QuestionNode = memo(function QuestionNode({
+export const QuestionNode = memo(function SearchTermsNode({
   data,
 }: {
-  data: QuestionNodeData
+  data: SearchTermsNodeData
 }) {
   return (
-    <Card className="min-w-[400px]">
-      <Handle type="target" position={Position.Top} />
-      <CardContent className="p-4">
-        {data.loading ? (
-          <div className="flex items-center gap-3">
-            <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
-            <p>Generating follow-up question...</p>
-          </div>
-        ) : data.error ? (
-          <div className="flex items-center gap-3 text-red-500">
-            <AlertCircle className="h-5 w-5" />
-            <p>{data.error}</p>
-          </div>
-        ) : data.question ? (
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <HelpCircle className="h-5 w-5 text-blue-500" />
-              <h3 className="font-medium">Follow-up Question</h3>
+    <div className="w-[400px]">
+      <Card className="overflow-hidden">
+        <Handle type="target" position={Position.Top} />
+        <CardContent className="p-4">
+          {data.loading ? (
+            <div className="flex items-center gap-3">
+              <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+              <p>Generating search terms...</p>
             </div>
-            <p className="text-gray-600">{data.question}</p>
-            <Button
-              size="sm"
-              className="w-full"
-              onClick={data.onApprove}
-            >
-              Research This Question
-            </Button>
-          </div>
-        ) : null}
-      </CardContent>
-    </Card>
+          ) : data.error ? (
+            <div className="flex items-center gap-3 text-red-500">
+              <Search className="h-5 w-5" />
+              <p>{data.error}</p>
+            </div>
+          ) : data.searchTerms?.length ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Search className="h-5 w-5 text-blue-500" />
+                <h3 className="font-medium">Follow-up Queries</h3>
+              </div>
+              <div className="space-y-2">
+                {data.searchTerms.map((term, index) => (
+                  <div key={index} className="flex items-center justify-between gap-2 p-2 rounded bg-gray-50">
+                    <p className="text-sm text-gray-600">{term}</p>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => data.onApprove?.(term)}
+                      className="h-8"
+                    >
+                      <Search className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+        <Handle type="source" position={Position.Bottom} />
+      </Card>
+    </div>
   )
 }) 

--- a/components/flow/question-node.tsx
+++ b/components/flow/question-node.tsx
@@ -12,45 +12,46 @@ type SearchTermsNodeData = {
   onApprove?: (term: string) => void
 }
 
-type SearchTermsNodeType = Node<SearchTermsNodeData>
-
 export const QuestionNode = memo(function SearchTermsNode({
   data,
 }: {
   data: SearchTermsNodeData
 }) {
   return (
-    <div className="w-[400px]">
-      <Card className="overflow-hidden">
-        <Handle type="target" position={Position.Top} />
-        <CardContent className="p-4">
+    <div className='w-[400px]'>
+      <Card className='overflow-hidden'>
+        <Handle type='target' position={Position.Top} />
+        <CardContent className='p-4'>
           {data.loading ? (
-            <div className="flex items-center gap-3">
-              <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+            <div className='flex items-center gap-3'>
+              <Loader2 className='h-5 w-5 animate-spin text-blue-500' />
               <p>Generating search terms...</p>
             </div>
           ) : data.error ? (
-            <div className="flex items-center gap-3 text-red-500">
-              <Search className="h-5 w-5" />
+            <div className='flex items-center gap-3 text-red-500'>
+              <Search className='h-5 w-5' />
               <p>{data.error}</p>
             </div>
           ) : data.searchTerms?.length ? (
-            <div className="space-y-4">
-              <div className="flex items-center gap-2">
-                <Search className="h-5 w-5 text-blue-500" />
-                <h3 className="font-medium">Follow-up Queries</h3>
+            <div className='space-y-4'>
+              <div className='flex items-center gap-2'>
+                <Search className='h-5 w-5 text-blue-500' />
+                <h3 className='font-medium'>Follow-up Queries</h3>
               </div>
-              <div className="space-y-2">
+              <div className='space-y-2'>
                 {data.searchTerms.map((term, index) => (
-                  <div key={index} className="flex items-center justify-between gap-2 p-2 rounded bg-gray-50">
-                    <p className="text-sm text-gray-600">{term}</p>
+                  <div
+                    key={index}
+                    className='flex items-center justify-between gap-2 p-2 rounded bg-gray-50'
+                  >
+                    <p className='text-sm text-gray-600'>{term}</p>
                     <Button
-                      size="sm"
-                      variant="ghost"
+                      size='sm'
+                      variant='ghost'
                       onClick={() => data.onApprove?.(term)}
-                      className="h-8"
+                      className='h-8'
                     >
-                      <Search className="h-4 w-4" />
+                      <Search className='h-4 w-4' />
                     </Button>
                   </div>
                 ))}
@@ -58,8 +59,8 @@ export const QuestionNode = memo(function SearchTermsNode({
             </div>
           ) : null}
         </CardContent>
-        <Handle type="source" position={Position.Bottom} />
+        <Handle type='source' position={Position.Bottom} />
       </Card>
     </div>
   )
-}) 
+})

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -1,10 +1,13 @@
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2 } from 'lucide-react'
+import { Loader2, ChevronDown } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ReportActions } from '@/components/report-actions'
 import type { Report } from '@/types'
+import { useState } from 'react'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Button } from '@/components/ui/button'
 
 interface ReportNodeProps {
   data: {
@@ -18,6 +21,7 @@ interface ReportNodeProps {
 
 export function ReportNode({ data }: ReportNodeProps) {
   const { report, loading, error, isSelected, isConsolidated } = data
+  const [isExpanded, setIsExpanded] = useState(false)
 
   return (
     <div className='w-[600px]'>
@@ -37,25 +41,37 @@ export function ReportNode({ data }: ReportNodeProps) {
           ) : error ? (
             <div className='text-red-500 text-center p-4'>{error}</div>
           ) : report ? (
-            <>
+            <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
               <div className='flex justify-between items-start gap-4'>
                 <h2 className='text-xl font-bold text-gray-800'>{report.title}</h2>
                 <ReportActions report={report} size='sm' />
               </div>
               <p className='text-gray-700'>{report.summary}</p>
-              {report.sections?.map((section, index) => (
-                <div key={index} className='space-y-2 border-t pt-4'>
-                  <h3 className='text-lg font-semibold text-gray-700'>
-                    {section.title}
-                  </h3>
-                  <div className='prose max-w-none text-gray-600'>
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                      {section.content}
-                    </ReactMarkdown>
-                  </div>
+              <CollapsibleContent>
+                <div className='space-y-4 mt-4'>
+                  {report.sections?.map((section, index) => (
+                    <div key={index} className='space-y-2 border-t pt-4'>
+                      <h3 className='text-lg font-semibold text-gray-700'>
+                        {section.title}
+                      </h3>
+                      <div className='prose max-w-none text-gray-600'>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {section.content}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </>
+              </CollapsibleContent>
+              <div className='flex justify-center mt-4 border-t pt-4'>
+                <CollapsibleTrigger asChild>
+                  <Button variant="link" size="sm" className="gap-2 text-blue-600">
+                    {isExpanded ? 'Show less' : 'View full report'}
+                    <ChevronDown className={`h-4 w-4 transition-transform ${isExpanded ? '-rotate-180' : ''}`} />
+                  </Button>
+                </CollapsibleTrigger>
+              </div>
+            </Collapsible>
           ) : null}
         </CardContent>
       </Card>

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -1,36 +1,54 @@
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, ChevronDown } from 'lucide-react'
+import { Loader2, ChevronDown, FileText } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ReportActions } from '@/components/report-actions'
 import type { Report } from '@/types'
 import { useState } from 'react'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { memo } from 'react'
 
-interface ReportNodeProps {
-  data: {
-    report?: Report
-    loading?: boolean
-    error?: string
-    isSelected?: boolean
-    isConsolidated?: boolean
-  }
+type ReportNodeData = {
+  report?: Report
+  loading: boolean
+  error?: string
+  isSelected?: boolean
+  onSelect?: (id: string) => void
+  isConsolidated?: boolean
+  isConsolidating?: boolean
 }
 
-export function ReportNode({ data }: ReportNodeProps) {
-  const { report, loading, error, isSelected, isConsolidated } = data
+export const ReportNode = memo(function ReportNode({
+  id,
+  data,
+}: {
+  id: string
+  data: ReportNodeData
+}) {
+  const {
+    report,
+    loading,
+    error,
+    isSelected,
+    isConsolidated,
+    onSelect,
+    isConsolidating,
+  } = data
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
     <div className='w-[600px]'>
       <Handle type='target' position={Position.Top} />
       <Card
-        className={`${
-          isSelected ? 'ring-2 ring-blue-500' : ''
-        } ${
-          isConsolidated ? 'bg-blue-50' : ''
+        className={`${isSelected ? 'ring-2 ring-blue-500' : ''} ${
+          isConsolidated ? 'border border-yellow-500' : ''
         }`}
       >
         <CardContent className='p-6 space-y-4'>
@@ -42,11 +60,22 @@ export function ReportNode({ data }: ReportNodeProps) {
             <div className='text-red-500 text-center p-4'>{error}</div>
           ) : report ? (
             <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
-              <div className='flex justify-between items-start gap-4'>
-                <h2 className='text-xl font-bold text-gray-800'>{report.title}</h2>
-                <ReportActions report={report} size='sm' />
+              <div className='space-y-2'>
+                <div className='flex items-baseline gap-3'>
+                  <Checkbox
+                    checked={isSelected}
+                    onCheckedChange={() => onSelect?.(id)}
+                    disabled={isConsolidating}
+                  />
+                  <h2 className='text-xl font-bold text-gray-800'>
+                    {report.title}
+                  </h2>
+                </div>
+                <div className='flex justify-start'>
+                  <ReportActions report={report} size='sm' />
+                </div>
+                <p className='text-gray-700'>{report.summary}</p>
               </div>
-              <p className='text-gray-700'>{report.summary}</p>
               <CollapsibleContent>
                 <div className='space-y-4 mt-4'>
                   {report.sections?.map((section, index) => (
@@ -65,9 +94,17 @@ export function ReportNode({ data }: ReportNodeProps) {
               </CollapsibleContent>
               <div className='flex justify-center mt-4 border-t pt-4'>
                 <CollapsibleTrigger asChild>
-                  <Button variant="link" size="sm" className="gap-2 text-blue-600">
+                  <Button
+                    variant='link'
+                    size='sm'
+                    className='gap-2 text-blue-600'
+                  >
                     {isExpanded ? 'Show less' : 'View full report'}
-                    <ChevronDown className={`h-4 w-4 transition-transform ${isExpanded ? '-rotate-180' : ''}`} />
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform ${
+                        isExpanded ? '-rotate-180' : ''
+                      }`}
+                    />
                   </Button>
                 </CollapsibleTrigger>
               </div>
@@ -78,4 +115,4 @@ export function ReportNode({ data }: ReportNodeProps) {
       <Handle type='source' position={Position.Bottom} />
     </div>
   )
-} 
+})

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -1,6 +1,6 @@
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, ChevronDown, FileText } from 'lucide-react'
+import { Loader2, ChevronDown } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ReportActions } from '@/components/report-actions'

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -1,0 +1,91 @@
+import { memo } from 'react'
+import type { Node } from '@xyflow/react'
+import { Handle, Position } from '@xyflow/react'
+import { Card, CardContent } from '@/components/ui/card'
+import { FileText, Loader2, ChevronDown } from 'lucide-react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import type { Report } from '@/types'
+import { Button } from '@/components/ui/button'
+
+type ReportNodeData = {
+  report?: Report
+  loading: boolean
+  error?: string
+  hasChildren: boolean
+  onConsolidate: () => void
+}
+
+type ReportNodeType = Node<ReportNodeData>
+
+export const ReportNode = memo(function ReportNode({
+  data,
+}: {
+  data: ReportNodeData
+}) {
+  return (
+    <Card className="min-w-[500px]">
+      <Handle type="target" position={Position.Top} />
+      <CardContent className="p-4">
+        {data.loading ? (
+          <div className="flex items-center gap-3">
+            <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+            <p>Generating report...</p>
+          </div>
+        ) : data.error ? (
+          <div className="flex items-center gap-3 text-red-500">
+            <FileText className="h-5 w-5" />
+            <p>{data.error}</p>
+          </div>
+        ) : data.report ? (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium flex items-center gap-2">
+                <FileText className="h-5 w-5 text-blue-500" />
+                Report
+              </h3>
+              {data.hasChildren && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={data.onConsolidate}
+                  className="gap-2"
+                >
+                  <FileText className="h-4 w-4" />
+                  Consolidate Chain
+                </Button>
+              )}
+            </div>
+            <div className="prose prose-sm max-w-none">
+              <h2 className="text-xl font-bold">{data.report.title}</h2>
+              <p className="text-gray-600">{data.report.summary}</p>
+              <Collapsible>
+                <CollapsibleTrigger className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
+                  View Full Report <ChevronDown className="h-4 w-4" />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="mt-4">
+                  {data.report.sections?.map((section, index) => (
+                    <div key={index} className="mt-4">
+                      <h3 className="font-semibold">{section.title}</h3>
+                      <div className="mt-2">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {section.content}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
+                  ))}
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+      <Handle type="source" position={Position.Bottom} />
+    </Card>
+  )
+}) 

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -1,119 +1,65 @@
-import { memo } from 'react'
-import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
-import { FileText, Loader2, ChevronDown } from 'lucide-react'
-import { Checkbox } from '@/components/ui/checkbox'
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
+import { Loader2 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { ReportActions } from '@/components/report-actions'
 import type { Report } from '@/types'
-import { Button } from '@/components/ui/button'
 
-type ReportNodeData = {
-  report?: Report
-  loading: boolean
-  error?: string
-  hasChildren: boolean
-  isSelected?: boolean
-  onSelect?: (id: string) => void
-  onConsolidate?: () => void
-  isConsolidated?: boolean
-  isConsolidating?: boolean
+interface ReportNodeProps {
+  data: {
+    report?: Report
+    loading?: boolean
+    error?: string
+    isSelected?: boolean
+    isConsolidated?: boolean
+  }
 }
 
-type ReportNodeType = Node<ReportNodeData>
+export function ReportNode({ data }: ReportNodeProps) {
+  const { report, loading, error, isSelected, isConsolidated } = data
 
-export const ReportNode = memo(function ReportNode({
-  id,
-  data,
-}: {
-  id: string
-  data: ReportNodeData
-}) {
   return (
-    <div className="w-[500px]">
-      <Card className={`overflow-hidden ${data.isConsolidated ? 'bg-blue-50 border-blue-200' : ''}`}>
-        <Handle type="target" position={Position.Top} />
-        <CardContent className="p-4">
-          {data.loading ? (
-            <div className="flex items-center gap-3">
-              <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
-              <p>Generating report...</p>
+    <div className='w-[600px]'>
+      <Handle type='target' position={Position.Top} />
+      <Card
+        className={`${
+          isSelected ? 'ring-2 ring-blue-500' : ''
+        } ${
+          isConsolidated ? 'bg-blue-50' : ''
+        }`}
+      >
+        <CardContent className='p-6 space-y-4'>
+          {loading ? (
+            <div className='flex items-center justify-center p-4'>
+              <Loader2 className='h-6 w-6 animate-spin' />
             </div>
-          ) : data.error ? (
-            <div className="flex items-center gap-3 text-red-500">
-              <FileText className="h-5 w-5" />
-              <p>{data.error}</p>
-            </div>
-          ) : data.report ? (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <Checkbox 
-                    checked={data.isSelected}
-                    onCheckedChange={() => data.onSelect?.(id)}
-                    disabled={data.isConsolidating}
-                  />
-                  <h3 className={`font-medium flex items-center gap-2 ${data.isConsolidated ? 'text-blue-700' : ''}`}>
-                    <FileText className={`h-5 w-5 ${data.isConsolidated ? 'text-blue-500' : ''}`} />
-                    {data.isConsolidated ? 'Consolidated Report' : 'Report'}
+          ) : error ? (
+            <div className='text-red-500 text-center p-4'>{error}</div>
+          ) : report ? (
+            <>
+              <div className='flex justify-between items-start gap-4'>
+                <h2 className='text-xl font-bold text-gray-800'>{report.title}</h2>
+                <ReportActions report={report} size='sm' />
+              </div>
+              <p className='text-gray-700'>{report.summary}</p>
+              {report.sections?.map((section, index) => (
+                <div key={index} className='space-y-2 border-t pt-4'>
+                  <h3 className='text-lg font-semibold text-gray-700'>
+                    {section.title}
                   </h3>
+                  <div className='prose max-w-none text-gray-600'>
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {section.content}
+                    </ReactMarkdown>
+                  </div>
                 </div>
-                {data.hasChildren && !data.isConsolidated && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={data.onConsolidate}
-                    disabled={data.isConsolidating}
-                    className="gap-2"
-                  >
-                    {data.isConsolidating ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Consolidating...
-                      </>
-                    ) : (
-                      <>
-                        <FileText className="h-4 w-4" />
-                        Consolidate Chain
-                      </>
-                    )}
-                  </Button>
-                )}
-              </div>
-              <div className="prose prose-sm max-w-none break-words">
-                <h2 className={`text-xl font-bold ${data.isConsolidated ? 'text-blue-900' : ''}`}>
-                  {data.report.title}
-                </h2>
-                <p className="text-gray-600">{data.report.summary}</p>
-                <Collapsible>
-                  <CollapsibleTrigger className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
-                    View Full Report <ChevronDown className="h-4 w-4" />
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="mt-4">
-                    {data.report.sections?.map((section, index) => (
-                      <div key={index} className="mt-4">
-                        <h3 className="font-semibold">{section.title}</h3>
-                        <div className="mt-2">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]} className="break-words">
-                            {section.content}
-                          </ReactMarkdown>
-                        </div>
-                      </div>
-                    ))}
-                  </CollapsibleContent>
-                </Collapsible>
-              </div>
-            </div>
+              ))}
+            </>
           ) : null}
         </CardContent>
-        <Handle type="source" position={Position.Bottom} />
       </Card>
+      <Handle type='source' position={Position.Bottom} />
     </div>
   )
-}) 
+} 

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -29,63 +29,65 @@ export const ReportNode = memo(function ReportNode({
   data: ReportNodeData
 }) {
   return (
-    <Card className="min-w-[500px]">
-      <Handle type="target" position={Position.Top} />
-      <CardContent className="p-4">
-        {data.loading ? (
-          <div className="flex items-center gap-3">
-            <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
-            <p>Generating report...</p>
-          </div>
-        ) : data.error ? (
-          <div className="flex items-center gap-3 text-red-500">
-            <FileText className="h-5 w-5" />
-            <p>{data.error}</p>
-          </div>
-        ) : data.report ? (
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <h3 className="font-medium flex items-center gap-2">
-                <FileText className="h-5 w-5 text-blue-500" />
-                Report
-              </h3>
-              {data.hasChildren && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={data.onConsolidate}
-                  className="gap-2"
-                >
-                  <FileText className="h-4 w-4" />
-                  Consolidate Chain
-                </Button>
-              )}
+    <div className="w-[500px]">
+      <Card className="overflow-hidden">
+        <Handle type="target" position={Position.Top} />
+        <CardContent className="p-4">
+          {data.loading ? (
+            <div className="flex items-center gap-3">
+              <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+              <p>Generating report...</p>
             </div>
-            <div className="prose prose-sm max-w-none">
-              <h2 className="text-xl font-bold">{data.report.title}</h2>
-              <p className="text-gray-600">{data.report.summary}</p>
-              <Collapsible>
-                <CollapsibleTrigger className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
-                  View Full Report <ChevronDown className="h-4 w-4" />
-                </CollapsibleTrigger>
-                <CollapsibleContent className="mt-4">
-                  {data.report.sections?.map((section, index) => (
-                    <div key={index} className="mt-4">
-                      <h3 className="font-semibold">{section.title}</h3>
-                      <div className="mt-2">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                          {section.content}
-                        </ReactMarkdown>
+          ) : data.error ? (
+            <div className="flex items-center gap-3 text-red-500">
+              <FileText className="h-5 w-5" />
+              <p>{data.error}</p>
+            </div>
+          ) : data.report ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="font-medium flex items-center gap-2">
+                  <FileText className="h-5 w-5 text-blue-500" />
+                  Report
+                </h3>
+                {data.hasChildren && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={data.onConsolidate}
+                    className="gap-2"
+                  >
+                    <FileText className="h-4 w-4" />
+                    Consolidate Chain
+                  </Button>
+                )}
+              </div>
+              <div className="prose prose-sm max-w-none break-words">
+                <h2 className="text-xl font-bold">{data.report.title}</h2>
+                <p className="text-gray-600">{data.report.summary}</p>
+                <Collapsible>
+                  <CollapsibleTrigger className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
+                    View Full Report <ChevronDown className="h-4 w-4" />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="mt-4">
+                    {data.report.sections?.map((section, index) => (
+                      <div key={index} className="mt-4">
+                        <h3 className="font-semibold">{section.title}</h3>
+                        <div className="mt-2">
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} className="break-words">
+                            {section.content}
+                          </ReactMarkdown>
+                        </div>
                       </div>
-                    </div>
-                  ))}
-                </CollapsibleContent>
-              </Collapsible>
+                    ))}
+                  </CollapsibleContent>
+                </Collapsible>
+              </div>
             </div>
-          </div>
-        ) : null}
-      </CardContent>
-      <Handle type="source" position={Position.Bottom} />
-    </Card>
+          ) : null}
+        </CardContent>
+        <Handle type="source" position={Position.Bottom} />
+      </Card>
+    </div>
   )
 }) 

--- a/components/flow/report-node.tsx
+++ b/components/flow/report-node.tsx
@@ -3,6 +3,7 @@ import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
 import { FileText, Loader2, ChevronDown } from 'lucide-react'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Collapsible,
   CollapsibleContent,
@@ -18,19 +19,25 @@ type ReportNodeData = {
   loading: boolean
   error?: string
   hasChildren: boolean
-  onConsolidate: () => void
+  isSelected?: boolean
+  onSelect?: (id: string) => void
+  onConsolidate?: () => void
+  isConsolidated?: boolean
+  isConsolidating?: boolean
 }
 
 type ReportNodeType = Node<ReportNodeData>
 
 export const ReportNode = memo(function ReportNode({
+  id,
   data,
 }: {
+  id: string
   data: ReportNodeData
 }) {
   return (
     <div className="w-[500px]">
-      <Card className="overflow-hidden">
+      <Card className={`overflow-hidden ${data.isConsolidated ? 'bg-blue-50 border-blue-200' : ''}`}>
         <Handle type="target" position={Position.Top} />
         <CardContent className="p-4">
           {data.loading ? (
@@ -46,24 +53,43 @@ export const ReportNode = memo(function ReportNode({
           ) : data.report ? (
             <div className="space-y-4">
               <div className="flex items-center justify-between">
-                <h3 className="font-medium flex items-center gap-2">
-                  <FileText className="h-5 w-5 text-blue-500" />
-                  Report
-                </h3>
-                {data.hasChildren && (
+                <div className="flex items-center gap-3">
+                  <Checkbox 
+                    checked={data.isSelected}
+                    onCheckedChange={() => data.onSelect?.(id)}
+                    disabled={data.isConsolidating}
+                  />
+                  <h3 className={`font-medium flex items-center gap-2 ${data.isConsolidated ? 'text-blue-700' : ''}`}>
+                    <FileText className={`h-5 w-5 ${data.isConsolidated ? 'text-blue-500' : ''}`} />
+                    {data.isConsolidated ? 'Consolidated Report' : 'Report'}
+                  </h3>
+                </div>
+                {data.hasChildren && !data.isConsolidated && (
                   <Button
                     variant="outline"
                     size="sm"
                     onClick={data.onConsolidate}
+                    disabled={data.isConsolidating}
                     className="gap-2"
                   >
-                    <FileText className="h-4 w-4" />
-                    Consolidate Chain
+                    {data.isConsolidating ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Consolidating...
+                      </>
+                    ) : (
+                      <>
+                        <FileText className="h-4 w-4" />
+                        Consolidate Chain
+                      </>
+                    )}
                   </Button>
                 )}
               </div>
               <div className="prose prose-sm max-w-none break-words">
-                <h2 className="text-xl font-bold">{data.report.title}</h2>
+                <h2 className={`text-xl font-bold ${data.isConsolidated ? 'text-blue-900' : ''}`}>
+                  {data.report.title}
+                </h2>
                 <p className="text-gray-600">{data.report.summary}</p>
                 <Collapsible>
                   <CollapsibleTrigger className="flex items-center gap-1 text-sm text-blue-600 hover:underline">

--- a/components/flow/search-node.tsx
+++ b/components/flow/search-node.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react'
-import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Search, Loader2 } from 'lucide-react'
@@ -9,31 +8,29 @@ type SearchNodeData = {
   loading: boolean
 }
 
-type SearchNodeType = Node<SearchNodeData>
-
 export const SearchNode = memo(function SearchNode({
   data,
 }: {
   data: SearchNodeData
 }) {
   return (
-    <div className="w-auto mx-auto">
+    <div className='w-auto mx-auto'>
       <Card>
-        <CardContent className="p-6">
-          <div className="flex items-center gap-4">
+        <CardContent className='p-6'>
+          <div className='flex items-center gap-4'>
             {data.loading ? (
-              <Loader2 className="h-6 w-6 animate-spin text-blue-500" />
+              <Loader2 className='h-6 w-6 animate-spin text-blue-500' />
             ) : (
-              <Search className="h-6 w-6 text-blue-500" />
+              <Search className='h-6 w-6 text-blue-500' />
             )}
-            <div className="space-y-1">
-              <h3 className="font-medium text-lg">Search Query</h3>
-              <p className="text-gray-600">{data.query}</p>
+            <div className='space-y-1'>
+              <h3 className='font-medium text-lg'>Search Query</h3>
+              <p className='text-gray-600'>{data.query}</p>
             </div>
           </div>
         </CardContent>
-        <Handle type="source" position={Position.Bottom} />
+        <Handle type='source' position={Position.Bottom} />
       </Card>
     </div>
   )
-}) 
+})

--- a/components/flow/search-node.tsx
+++ b/components/flow/search-node.tsx
@@ -17,18 +17,18 @@ export const SearchNode = memo(function SearchNode({
   data: SearchNodeData
 }) {
   return (
-    <div className="w-[70%] mx-auto">
+    <div className="w-auto mx-auto">
       <Card>
-        <CardContent className="p-4">
-          <div className="flex items-center gap-3">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-4">
             {data.loading ? (
-              <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+              <Loader2 className="h-6 w-6 animate-spin text-blue-500" />
             ) : (
-              <Search className="h-5 w-5 text-blue-500" />
+              <Search className="h-6 w-6 text-blue-500" />
             )}
-            <div>
-              <h3 className="font-medium">Search Query</h3>
-              <p className="text-sm text-gray-600">{data.query}</p>
+            <div className="space-y-1">
+              <h3 className="font-medium text-lg">Search Query</h3>
+              <p className="text-gray-600">{data.query}</p>
             </div>
           </div>
         </CardContent>

--- a/components/flow/search-node.tsx
+++ b/components/flow/search-node.tsx
@@ -17,21 +17,23 @@ export const SearchNode = memo(function SearchNode({
   data: SearchNodeData
 }) {
   return (
-    <Card className="min-w-[300px]">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-3">
-          {data.loading ? (
-            <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
-          ) : (
-            <Search className="h-5 w-5 text-blue-500" />
-          )}
-          <div>
-            <h3 className="font-medium">Search Query</h3>
-            <p className="text-sm text-gray-600">{data.query}</p>
+    <div className="w-[70%] mx-auto">
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-3">
+            {data.loading ? (
+              <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+            ) : (
+              <Search className="h-5 w-5 text-blue-500" />
+            )}
+            <div>
+              <h3 className="font-medium">Search Query</h3>
+              <p className="text-sm text-gray-600">{data.query}</p>
+            </div>
           </div>
-        </div>
-      </CardContent>
-      <Handle type="source" position={Position.Bottom} />
-    </Card>
+        </CardContent>
+        <Handle type="source" position={Position.Bottom} />
+      </Card>
+    </div>
   )
 }) 

--- a/components/flow/search-node.tsx
+++ b/components/flow/search-node.tsx
@@ -1,0 +1,37 @@
+import { memo } from 'react'
+import type { Node } from '@xyflow/react'
+import { Handle, Position } from '@xyflow/react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Search, Loader2 } from 'lucide-react'
+
+type SearchNodeData = {
+  query: string
+  loading: boolean
+}
+
+type SearchNodeType = Node<SearchNodeData>
+
+export const SearchNode = memo(function SearchNode({
+  data,
+}: {
+  data: SearchNodeData
+}) {
+  return (
+    <Card className="min-w-[300px]">
+      <CardContent className="p-4">
+        <div className="flex items-center gap-3">
+          {data.loading ? (
+            <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+          ) : (
+            <Search className="h-5 w-5 text-blue-500" />
+          )}
+          <div>
+            <h3 className="font-medium">Search Query</h3>
+            <p className="text-sm text-gray-600">{data.query}</p>
+          </div>
+        </div>
+      </CardContent>
+      <Handle type="source" position={Position.Bottom} />
+    </Card>
+  )
+}) 

--- a/components/flow/selection-node.tsx
+++ b/components/flow/selection-node.tsx
@@ -1,5 +1,4 @@
 import { memo, useState, useEffect } from 'react'
-import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -11,8 +10,6 @@ type SelectionNodeData = {
   results: SearchResult[]
   onGenerateReport: (selectedResults: SearchResult[]) => void
 }
-
-type SelectionNodeType = Node<SelectionNodeData>
 
 const MAX_SELECTIONS = 3
 
@@ -49,33 +46,37 @@ export const SelectionNode = memo(function SelectionNode({
   }
 
   return (
-    <div className="w-auto max-w-[600px] mx-auto">
+    <div className='w-auto max-w-[600px] mx-auto'>
       <Card>
-        <Handle type="target" position={Position.Top} />
-        <CardContent className="p-6">
-          <div className="space-y-6">
-            <div className="flex items-center justify-between">
-              <h3 className="font-medium text-lg flex items-center gap-3">
-                <FileText className="h-6 w-6 text-blue-500" />
+        <Handle type='target' position={Position.Top} />
+        <CardContent className='p-6'>
+          <div className='space-y-6'>
+            <div className='flex items-center justify-between'>
+              <h3 className='font-medium text-lg flex items-center gap-3'>
+                <FileText className='h-6 w-6 text-blue-500' />
                 Search Results
               </h3>
               <Button
-                size="default"
+                size='default'
                 disabled={selectedResults.length === 0}
                 onClick={handleGenerateReport}
-                className="gap-2"
+                className='gap-2'
               >
-                <FileText className="h-4 w-4" />
+                <FileText className='h-4 w-4' />
                 Generate Report ({selectedResults.length})
               </Button>
             </div>
-            <p className="text-gray-600">
-              Select up to {MAX_SELECTIONS} results to analyze ({selectedResults.length} selected)
+            <p className='text-gray-600'>
+              Select up to {MAX_SELECTIONS} results to analyze (
+              {selectedResults.length} selected)
             </p>
-            <div className="space-y-4 max-h-[400px] overflow-y-auto pr-4">
+            <div className='space-y-4 max-h-[400px] overflow-y-auto pr-4 nowheel nodrag'>
               {data.results.map((result) => (
-                <div key={result.id} className="flex items-start gap-4 bg-gray-50 p-4 rounded-lg">
-                  <div className="pt-1">
+                <div
+                  key={result.id}
+                  className='flex items-start gap-4 bg-gray-50 p-4 rounded-lg'
+                >
+                  <div className='pt-1'>
                     <Checkbox
                       checked={selectedResults.some((r) => r.id === result.id)}
                       onCheckedChange={() => handleSelect(result)}
@@ -85,17 +86,19 @@ export const SelectionNode = memo(function SelectionNode({
                       }
                     />
                   </div>
-                  <div className="space-y-2 flex-1">
+                  <div className='space-y-2 flex-1'>
                     <a
                       href={result.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:underline font-medium block"
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='text-blue-600 hover:underline font-medium block'
                     >
                       {result.name}
                     </a>
-                    <p className="text-sm text-green-700 truncate">{result.url}</p>
-                    <p className="text-gray-600 line-clamp-3">
+                    <p className='text-sm text-green-700 truncate'>
+                      {result.url}
+                    </p>
+                    <p className='text-gray-600 line-clamp-3'>
                       {result.snippet}
                     </p>
                   </div>
@@ -104,8 +107,8 @@ export const SelectionNode = memo(function SelectionNode({
             </div>
           </div>
         </CardContent>
-        <Handle type="source" position={Position.Bottom} />
+        <Handle type='source' position={Position.Bottom} />
       </Card>
     </div>
   )
-}) 
+})

--- a/components/flow/selection-node.tsx
+++ b/components/flow/selection-node.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react'
+import { memo, useState, useEffect } from 'react'
 import type { Node } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Card, CardContent } from '@/components/ui/card'
@@ -23,7 +23,13 @@ export const SelectionNode = memo(function SelectionNode({
 }) {
   const [selectedResults, setSelectedResults] = useState<SearchResult[]>([])
 
+  // Reset selection when results change
+  useEffect(() => {
+    setSelectedResults([])
+  }, [data.results])
+
   const handleSelect = (result: SearchResult) => {
+    console.log('Selecting result:', result)
     setSelectedResults((prev) => {
       if (prev.find((r) => r.id === result.id)) {
         return prev.filter((r) => r.id !== result.id)
@@ -33,60 +39,71 @@ export const SelectionNode = memo(function SelectionNode({
     })
   }
 
+  const handleGenerateReport = () => {
+    console.log('Generating report with selected results:', selectedResults)
+    if (selectedResults.length === 0) {
+      console.warn('No results selected')
+      return
+    }
+    data.onGenerateReport(selectedResults)
+  }
+
   return (
-    <Card className="min-w-[400px]">
-      <Handle type="target" position={Position.Top} />
-      <CardContent className="p-4">
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <h3 className="font-medium flex items-center gap-2">
-              <FileText className="h-5 w-5 text-blue-500" />
-              Search Results
-            </h3>
-            <Button
-              size="sm"
-              disabled={selectedResults.length === 0}
-              onClick={() => data.onGenerateReport(selectedResults)}
-            >
-              Generate Report
-            </Button>
-          </div>
-          <p className="text-sm text-gray-600">
-            Select up to {MAX_SELECTIONS} results to analyze
-          </p>
-          <div className="space-y-3 max-h-[300px] overflow-y-auto">
-            {data.results.map((result) => (
-              <div key={result.id} className="flex items-start gap-3">
-                <div className="pt-1">
-                  <Checkbox
-                    checked={selectedResults.some((r) => r.id === result.id)}
-                    onCheckedChange={() => handleSelect(result)}
-                    disabled={
-                      !selectedResults.some((r) => r.id === result.id) &&
-                      selectedResults.length >= MAX_SELECTIONS
-                    }
-                  />
+    <div className="w-[70%] mx-auto">
+      <Card>
+        <Handle type="target" position={Position.Top} />
+        <CardContent className="p-4">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium flex items-center gap-2">
+                <FileText className="h-5 w-5 text-blue-500" />
+                Search Results
+              </h3>
+              <Button
+                size="sm"
+                disabled={selectedResults.length === 0}
+                onClick={handleGenerateReport}
+              >
+                Generate Report ({selectedResults.length})
+              </Button>
+            </div>
+            <p className="text-sm text-gray-600">
+              Select up to {MAX_SELECTIONS} results to analyze ({selectedResults.length} selected)
+            </p>
+            <div className="space-y-3 max-h-[300px] overflow-y-auto">
+              {data.results.map((result) => (
+                <div key={result.id} className="flex items-start gap-3">
+                  <div className="pt-1">
+                    <Checkbox
+                      checked={selectedResults.some((r) => r.id === result.id)}
+                      onCheckedChange={() => handleSelect(result)}
+                      disabled={
+                        !selectedResults.some((r) => r.id === result.id) &&
+                        selectedResults.length >= MAX_SELECTIONS
+                      }
+                    />
+                  </div>
+                  <div>
+                    <a
+                      href={result.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline font-medium"
+                    >
+                      {result.name}
+                    </a>
+                    <p className="text-xs text-green-700 truncate">{result.url}</p>
+                    <p className="text-sm text-gray-600 line-clamp-2">
+                      {result.snippet}
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <a
-                    href={result.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline font-medium"
-                  >
-                    {result.name}
-                  </a>
-                  <p className="text-xs text-green-700 truncate">{result.url}</p>
-                  <p className="text-sm text-gray-600 line-clamp-2">
-                    {result.snippet}
-                  </p>
-                </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
-      </CardContent>
-      <Handle type="source" position={Position.Bottom} />
-    </Card>
+        </CardContent>
+        <Handle type="source" position={Position.Bottom} />
+      </Card>
+    </div>
   )
 }) 

--- a/components/flow/selection-node.tsx
+++ b/components/flow/selection-node.tsx
@@ -49,30 +49,32 @@ export const SelectionNode = memo(function SelectionNode({
   }
 
   return (
-    <div className="w-[70%] mx-auto">
+    <div className="w-auto max-w-[600px] mx-auto">
       <Card>
         <Handle type="target" position={Position.Top} />
-        <CardContent className="p-4">
-          <div className="space-y-4">
+        <CardContent className="p-6">
+          <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h3 className="font-medium flex items-center gap-2">
-                <FileText className="h-5 w-5 text-blue-500" />
+              <h3 className="font-medium text-lg flex items-center gap-3">
+                <FileText className="h-6 w-6 text-blue-500" />
                 Search Results
               </h3>
               <Button
-                size="sm"
+                size="default"
                 disabled={selectedResults.length === 0}
                 onClick={handleGenerateReport}
+                className="gap-2"
               >
+                <FileText className="h-4 w-4" />
                 Generate Report ({selectedResults.length})
               </Button>
             </div>
-            <p className="text-sm text-gray-600">
+            <p className="text-gray-600">
               Select up to {MAX_SELECTIONS} results to analyze ({selectedResults.length} selected)
             </p>
-            <div className="space-y-3 max-h-[300px] overflow-y-auto">
+            <div className="space-y-4 max-h-[400px] overflow-y-auto pr-4">
               {data.results.map((result) => (
-                <div key={result.id} className="flex items-start gap-3">
+                <div key={result.id} className="flex items-start gap-4 bg-gray-50 p-4 rounded-lg">
                   <div className="pt-1">
                     <Checkbox
                       checked={selectedResults.some((r) => r.id === result.id)}
@@ -83,17 +85,17 @@ export const SelectionNode = memo(function SelectionNode({
                       }
                     />
                   </div>
-                  <div>
+                  <div className="space-y-2 flex-1">
                     <a
                       href={result.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-blue-600 hover:underline font-medium"
+                      className="text-blue-600 hover:underline font-medium block"
                     >
                       {result.name}
                     </a>
-                    <p className="text-xs text-green-700 truncate">{result.url}</p>
-                    <p className="text-sm text-gray-600 line-clamp-2">
+                    <p className="text-sm text-green-700 truncate">{result.url}</p>
+                    <p className="text-gray-600 line-clamp-3">
                       {result.snippet}
                     </p>
                   </div>

--- a/components/flow/selection-node.tsx
+++ b/components/flow/selection-node.tsx
@@ -4,14 +4,16 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { FileText } from 'lucide-react'
+import { Input } from '@/components/ui/input'
 import type { SearchResult } from '@/types'
+import { CONFIG } from '@/lib/config'
 
 type SelectionNodeData = {
   results: SearchResult[]
-  onGenerateReport: (selectedResults: SearchResult[]) => void
+  onGenerateReport: (selectedResults: SearchResult[], prompt: string) => void
 }
 
-const MAX_SELECTIONS = 3
+const MAX_SELECTIONS = CONFIG.search.maxSelectableResults
 
 export const SelectionNode = memo(function SelectionNode({
   data,
@@ -19,6 +21,7 @@ export const SelectionNode = memo(function SelectionNode({
   data: SelectionNodeData
 }) {
   const [selectedResults, setSelectedResults] = useState<SearchResult[]>([])
+  const [prompt, setPrompt] = useState('')
 
   // Reset selection when results change
   useEffect(() => {
@@ -42,7 +45,7 @@ export const SelectionNode = memo(function SelectionNode({
       console.warn('No results selected')
       return
     }
-    data.onGenerateReport(selectedResults)
+    data.onGenerateReport(selectedResults, prompt)
   }
 
   return (
@@ -70,6 +73,13 @@ export const SelectionNode = memo(function SelectionNode({
               Select up to {MAX_SELECTIONS} results to analyze (
               {selectedResults.length} selected)
             </p>
+            {selectedResults.length > 0 && (
+              <Input
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder='What would you like to know about these sources?'
+              />
+            )}
             <div className='space-y-4 max-h-[400px] overflow-y-auto pr-4 nowheel nodrag'>
               {data.results.map((result) => (
                 <div

--- a/components/flow/selection-node.tsx
+++ b/components/flow/selection-node.tsx
@@ -1,0 +1,92 @@
+import { memo, useState } from 'react'
+import type { Node } from '@xyflow/react'
+import { Handle, Position } from '@xyflow/react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { FileText } from 'lucide-react'
+import type { SearchResult } from '@/types'
+
+type SelectionNodeData = {
+  results: SearchResult[]
+  onGenerateReport: (selectedResults: SearchResult[]) => void
+}
+
+type SelectionNodeType = Node<SelectionNodeData>
+
+const MAX_SELECTIONS = 3
+
+export const SelectionNode = memo(function SelectionNode({
+  data,
+}: {
+  data: SelectionNodeData
+}) {
+  const [selectedResults, setSelectedResults] = useState<SearchResult[]>([])
+
+  const handleSelect = (result: SearchResult) => {
+    setSelectedResults((prev) => {
+      if (prev.find((r) => r.id === result.id)) {
+        return prev.filter((r) => r.id !== result.id)
+      }
+      if (prev.length >= MAX_SELECTIONS) return prev
+      return [...prev, result]
+    })
+  }
+
+  return (
+    <Card className="min-w-[400px]">
+      <Handle type="target" position={Position.Top} />
+      <CardContent className="p-4">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="font-medium flex items-center gap-2">
+              <FileText className="h-5 w-5 text-blue-500" />
+              Search Results
+            </h3>
+            <Button
+              size="sm"
+              disabled={selectedResults.length === 0}
+              onClick={() => data.onGenerateReport(selectedResults)}
+            >
+              Generate Report
+            </Button>
+          </div>
+          <p className="text-sm text-gray-600">
+            Select up to {MAX_SELECTIONS} results to analyze
+          </p>
+          <div className="space-y-3 max-h-[300px] overflow-y-auto">
+            {data.results.map((result) => (
+              <div key={result.id} className="flex items-start gap-3">
+                <div className="pt-1">
+                  <Checkbox
+                    checked={selectedResults.some((r) => r.id === result.id)}
+                    onCheckedChange={() => handleSelect(result)}
+                    disabled={
+                      !selectedResults.some((r) => r.id === result.id) &&
+                      selectedResults.length >= MAX_SELECTIONS
+                    }
+                  />
+                </div>
+                <div>
+                  <a
+                    href={result.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline font-medium"
+                  >
+                    {result.name}
+                  </a>
+                  <p className="text-xs text-green-700 truncate">{result.url}</p>
+                  <p className="text-sm text-gray-600 line-clamp-2">
+                    {result.snippet}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+      <Handle type="source" position={Position.Bottom} />
+    </Card>
+  )
+}) 

--- a/components/report-actions.tsx
+++ b/components/report-actions.tsx
@@ -16,6 +16,7 @@ interface ReportActionsProps {
   size?: 'default' | 'sm'
   variant?: 'default' | 'outline'
   className?: string
+  hideKnowledgeBase?: boolean
 }
 
 export function ReportActions({
@@ -24,6 +25,7 @@ export function ReportActions({
   size = 'sm',
   variant = 'outline',
   className = '',
+  hideKnowledgeBase = false,
 }: ReportActionsProps) {
   const { addReport } = useKnowledgeBase()
   const { toast } = useToast()
@@ -69,15 +71,17 @@ export function ReportActions({
 
   return (
     <div className={`flex gap-2 ${className}`}>
-      <Button
-        variant={variant}
-        size={size}
-        className='gap-2'
-        onClick={handleSaveToKnowledgeBase}
-      >
-        <Brain className='h-4 w-4' />
-        Save to Knowledge Base
-      </Button>
+      {!hideKnowledgeBase && (
+        <Button
+          variant={variant}
+          size={size}
+          className='gap-2'
+          onClick={handleSaveToKnowledgeBase}
+        >
+          <Brain className='h-4 w-4' />
+          Save to Knowledge Base
+        </Button>
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant={variant} size={size} className='gap-2'>
@@ -99,4 +103,4 @@ export function ReportActions({
       </DropdownMenu>
     </div>
   )
-} 
+}

--- a/components/report-actions.tsx
+++ b/components/report-actions.tsx
@@ -13,7 +13,7 @@ import type { Report } from '@/types'
 interface ReportActionsProps {
   report: Report
   prompt?: string
-  size?: 'sm'
+  size?: 'default' | 'sm'
   variant?: 'default' | 'outline'
   className?: string
 }

--- a/components/report-actions.tsx
+++ b/components/report-actions.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@/components/ui/button'
+import { Brain, Download } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useToast } from '@/hooks/use-toast'
+import { useKnowledgeBase } from '@/lib/hooks/use-knowledge-base'
+import type { Report } from '@/types'
+
+interface ReportActionsProps {
+  report: Report
+  prompt?: string
+  size?: 'sm'
+  variant?: 'default' | 'outline'
+  className?: string
+}
+
+export function ReportActions({
+  report,
+  prompt,
+  size = 'sm',
+  variant = 'outline',
+  className = '',
+}: ReportActionsProps) {
+  const { addReport } = useKnowledgeBase()
+  const { toast } = useToast()
+
+  const handleDownload = async (format: 'pdf' | 'docx' | 'txt') => {
+    try {
+      const response = await fetch('/api/download', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          report,
+          format,
+        }),
+      })
+
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `report.${format}`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+    } catch (error) {
+      toast({
+        title: 'Download failed',
+        description: error instanceof Error ? error.message : 'Download failed',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const handleSaveToKnowledgeBase = () => {
+    const success = addReport(report, prompt || '')
+    if (success) {
+      toast({
+        title: 'Saved to Knowledge Base',
+        description: 'The report has been saved for future reference',
+      })
+    }
+  }
+
+  return (
+    <div className={`flex gap-2 ${className}`}>
+      <Button
+        variant={variant}
+        size={size}
+        className='gap-2'
+        onClick={handleSaveToKnowledgeBase}
+      >
+        <Brain className='h-4 w-4' />
+        Save to Knowledge Base
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant={variant} size={size} className='gap-2'>
+            <Download className='h-4 w-4' />
+            Download
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end'>
+          <DropdownMenuItem onClick={() => handleDownload('pdf')}>
+            Download as PDF
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleDownload('docx')}>
+            Download as Word
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleDownload('txt')}>
+            Download as Text
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+} 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/markdown-it": "^14.1.2",
         "@upstash/ratelimit": "^2.0.5",
         "@upstash/redis": "^1.34.3",
+        "@xyflow/react": "^12.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -1785,6 +1786,49 @@
         "node": ">=4"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2160,6 +2204,34 @@
       "integrity": "sha512-VT25TyODGy/8ljl7GADnJoMmtmJ1F8d84UXfGonRRF8fWYJz7+2J6GzW+a6ETGtk4OyuRTt7FRSvFG5GvrfSdQ==",
       "dependencies": {
         "crypto-js": "^4.2.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.4.3",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.4.3.tgz",
+      "integrity": "sha512-oO50TIY4rbgOURK5pmvL4LwLOQdh6YkvrvOBZPBedltJ1TINCRp0FiyYKfYhLnaDcW8/aayvGtFpUcSkPQxpGg==",
+      "dependencies": {
+        "@xyflow/system": "0.0.51",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.51.tgz",
+      "integrity": "sha512-cYnuM3oWQQjx2Rdz0LdZCnbUaWZdZDiik20kPDYsa5SIlq++ZDIcKiDF6a93ncfMv9Ej5GWfDkouE7bObrdRqQ==",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2801,6 +2873,11 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2953,6 +3030,102 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8256,6 +8429,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8548,6 +8729,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
+      "integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/markdown-it": "^14.1.2",
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.34.3",
+    "@xyflow/react": "^12.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
I'm super excited about this feature! It's an attempt to actually mimic deep research.

As flattered as I am about this repo getting some attention, I feel the way I initially set it up wasn’t really deep research. It was shallow research, aka, you have one forward pass: you search for a query, you scrape, and you synthesize (SSS...that's my marketing term for it).

But in reality, you SSS, then you have follow-up questions, and sometimes you go down rabbit holes. I was really inspired by [this other repo](https://github.com/dzhng/deep-research) and recommend y'all check it out.

So, I wanted to see if there’s a UI that can capture this workflow, and I landed on flowcharts. The idea is that a user can come in, do SSS (search, scrape, and synthesize a report for a query), and then generate follow-up queries, continuously creating reports.

You can then consolidate these intermediate reports into a final report. The flowchart UI gives you complete control and visibility into the whole process, allowing you to generate and save intermediate reports and mix and match them at any stage.

Here is a [Loom](https://www.loom.com/share/3c4d9811ac1d47eeaa7a0907c43aef7f) demonstrating this workflow in action.

Hope you all like it and appreciate any feedback! :)